### PR TITLE
Improve llm defaults

### DIFF
--- a/packages/core/src/__tests__/unit/source_builder.test.ts
+++ b/packages/core/src/__tests__/unit/source_builder.test.ts
@@ -28,12 +28,29 @@ describe('Source builders', () => {
     });
   });
 
-  it('builds LlmSource via builder', async () => {
+  it('uses default OpenAI configuration when none provided', async () => {
+    process.env.OPENAI_API_KEY = 'env-key';
+    const assistant = new Assistant(Source.llm());
+
+    await assistant.execute(createSession());
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        provider: expect.objectContaining({
+          type: 'openai',
+          apiKey: 'env-key',
+          modelName: 'gpt-4o-mini',
+        }),
+      }),
+    );
+  });
+
+  it('configures LlmSource via chaining', async () => {
     const assistant = new Assistant(
       Source.llm()
         .openai({ apiKey: 'key', modelName: 'gpt-4' })
-        .temperature(0.5)
-        .build(),
+        .temperature(0.5),
     );
 
     await assistant.execute(createSession());
@@ -50,11 +67,10 @@ describe('Source builders', () => {
     );
   });
 
-  it('builds LlmSource with Google provider', async () => {
+  it('configures LlmSource with Google provider', async () => {
     const assistant = new Assistant(
       Source.google({ apiKey: 'g-key', modelName: 'gemini-pro' })
-        .temperature(0.2)
-        .build(),
+        .temperature(0.2),
     );
 
     await assistant.execute(createSession());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export { tool } from 'ai';
 export * from './content_source';
 export * from './generate';
-export { createGenerateOptions, GenerateOptions } from './generate_options';
+// GenerateOptions is now internal to LlmSource
 export * from './message';
 export { createSession } from './session';
 export * from './tagged_record';


### PR DESCRIPTION
## Summary
- merge `LlmBuilder` into `LlmSource` so `Source.llm()` returns a configured instance
- add provider helper methods and sensible defaults
- update unit tests for new chaining API
- drop `GenerateOptions` export

## Testing
- `pnpm lint` *(fails: 237 errors)*
- `pnpm test` *(fails: Cannot connect to API: getaddrinfo ENOTFOUND api.openai.com)*
