### PR TITLE
Improve llm defaults

### DIFF
--- a/packages/core/src/__tests__/unit/source_builder.test.ts
+++ b/packages/core/src/__tests__/unit/source_builder.test.ts
@@ -28,6 +28,24 @@ describe('Source builders', () => {
     });
   });
 
+  it('uses default OpenAI configuration when none provided', async () => {
+    process.env.OPENAI_API_KEY = 'env-key';
+    const assistant = new Assistant(Source.llm().build());
+
+    await assistant.execute(createSession());
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        provider: expect.objectContaining({
+          type: 'openai',
+          apiKey: 'env-key',
+          modelName: 'gpt-4o-mini',
+        }),
+      }),
+    );
+  });
+
   it('builds LlmSource via builder', async () => {
     const assistant = new Assistant(
       Source.llm()

--- a/packages/core/src/__tests__/unit/templates/default_content_source.test.ts
+++ b/packages/core/src/__tests__/unit/templates/default_content_source.test.ts
@@ -62,7 +62,7 @@ describe('Default Content Source', () => {
         provider: {
           type: 'openai',
           apiKey: 'test-api-key',
-          modelName: 'gpt-4',
+          modelName: 'gpt-4o-mini',
         },
       });
 
@@ -90,7 +90,7 @@ describe('Default Content Source', () => {
         expect.objectContaining({
           provider: expect.objectContaining({
             type: 'openai',
-            modelName: 'gpt-4',
+          modelName: 'gpt-4o-mini',
           }),
         }),
       );

--- a/packages/core/src/content_source.ts
+++ b/packages/core/src/content_source.ts
@@ -639,21 +639,37 @@ export class LlmBuilder {
   private validation: ValidationOptions = {};
 
   constructor() {
-    // Provide dummy provider; user should override via openai()/anthropic()/google()
+    // Use sensible defaults: OpenAI provider with env API key and gpt-4o-mini model
     this.options = createGenerateOptions({
-      provider: { type: 'openai', apiKey: '', modelName: '' },
+      provider: {
+        type: 'openai',
+        apiKey: process.env.OPENAI_API_KEY || '',
+        modelName: 'gpt-4o-mini',
+      },
     });
   }
 
   /** Configure OpenAI provider */
-  openai(cfg: Omit<OpenAIProviderConfig, 'type'>) {
-    this.options.provider = { type: 'openai', ...cfg };
+  openai(cfg: Partial<Omit<OpenAIProviderConfig, 'type'>> = {}) {
+    this.options.provider = {
+      type: 'openai',
+      apiKey: cfg.apiKey ?? process.env.OPENAI_API_KEY ?? '',
+      modelName: cfg.modelName ?? 'gpt-4o-mini',
+      baseURL: cfg.baseURL,
+      organization: cfg.organization,
+      dangerouslyAllowBrowser: cfg.dangerouslyAllowBrowser,
+    };
     return this;
   }
 
   /** Configure Anthropic provider */
-  anthropic(cfg: Omit<AnthropicProviderConfig, 'type'>) {
-    this.options.provider = { type: 'anthropic', ...cfg };
+  anthropic(cfg: Partial<Omit<AnthropicProviderConfig, 'type'>> = {}) {
+    this.options.provider = {
+      type: 'anthropic',
+      apiKey: cfg.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '',
+      modelName: cfg.modelName ?? 'claude-3.7-haiku',
+      baseURL: cfg.baseURL,
+    };
     return this;
   }
 


### PR DESCRIPTION
## Summary
- better defaults for `Source.llm()`
- allow partial provider config and provide defaults
- test that defaults read env vars
- update default model expectations in default content source tests

## Testing
- `pnpm test` *(fails: Cannot connect to API: getaddrinfo ENOTFOUND api.openai.com)*