### PR TITLE
fix: discord testing fixture lags the async store read migration

### DIFF
--- a/packages/discord/src/__tests__/unit/runtime_bindings_mock.test.ts
+++ b/packages/discord/src/__tests__/unit/runtime_bindings_mock.test.ts
@@ -290,13 +290,13 @@ describe('runtime bindings with mock Discord and cron', () => {
       autoThread: false,
     });
 
-    expect(fixture.runtime.conversations()).toContainEqual({
+    expect(await fixture.runtime.conversations()).toContainEqual({
       id: 'discord:guild:workroom:channel:C_cloud:user:U_alice',
       agent: 'main',
       status: 'done',
     });
     expect(
-      fixture.runtime.inbox(
+      await fixture.runtime.inbox(
         'discord:guild:workroom:channel:C_cloud:user:U_alice',
       ),
     ).toContainEqual(
@@ -328,7 +328,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       content: 'hello from elsewhere',
     });
 
-    expect(fixture.runtime.conversations()).toEqual([]);
+    expect(await fixture.runtime.conversations()).toEqual([]);
     expect(fixture.discord.deliveries()).toEqual([]);
   });
 
@@ -342,7 +342,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       mentionsBot: false,
     });
 
-    expect(fixture.runtime.conversations()).toEqual([]);
+    expect(await fixture.runtime.conversations()).toEqual([]);
 
     await fixture.discord.receive({
       channel: 'cloud-lab',
@@ -351,7 +351,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       mentionsBot: true,
     });
 
-    expect(fixture.runtime.conversations()).toContainEqual(
+    expect(await fixture.runtime.conversations()).toContainEqual(
       expect.objectContaining({
         id: 'discord:guild:workroom:channel:C_cloud:user:U_alice',
       }),
@@ -374,7 +374,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       autoThread: false,
     });
 
-    expect(fixture.runtime.conversations()).toEqual(
+    expect(await fixture.runtime.conversations()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: 'discord:guild:workroom:channel:C_cloud:user:U_alice',
@@ -399,7 +399,7 @@ describe('runtime bindings with mock Discord and cron', () => {
     });
 
     expect(
-      fixture.runtime.inbox('discord:guild:workroom:thread:T_incident'),
+      await fixture.runtime.inbox('discord:guild:workroom:thread:T_incident'),
     ).toEqual([
       expect.objectContaining({ author: 'alice' }),
       expect.objectContaining({ author: 'bob' }),
@@ -422,7 +422,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       content: 'I see the same failure',
     });
 
-    expect(fixture.runtime.conversations()).toEqual(
+    expect(await fixture.runtime.conversations()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: 'discord:guild:workroom:thread:T_incident:user:U_alice',
@@ -448,7 +448,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       channel: 'cloud-lab',
       thread: 'T_cloud-lab_1',
     });
-    expect(fixture.runtime.conversations()).toContainEqual(
+    expect(await fixture.runtime.conversations()).toContainEqual(
       expect.objectContaining({
         id: 'discord:guild:workroom:thread:T_cloud-lab_1',
       }),
@@ -471,7 +471,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       content: 'inspect logs',
     });
 
-    expect(fixture.runtime.lastAssistantObservation()).toMatchObject({
+    expect(await fixture.runtime.lastAssistantObservation()).toMatchObject({
       conversationId: 'discord:guild:workroom:thread:T_debug',
       delivery: {
         platform: 'discord',
@@ -502,7 +502,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       author: 'alice',
       content: 'regular thread',
     });
-    expect(fixture.runtime.lastAssistantObservation()).toMatchObject({
+    expect(await fixture.runtime.lastAssistantObservation()).toMatchObject({
       channelPrompt: 'Infrastructure debug mode.',
       skills: ['cloud-ops-debugging'],
     });
@@ -513,7 +513,7 @@ describe('runtime bindings with mock Discord and cron', () => {
       author: 'alice',
       content: 'special thread',
     });
-    expect(fixture.runtime.lastAssistantObservation()).toMatchObject({
+    expect(await fixture.runtime.lastAssistantObservation()).toMatchObject({
       channelPrompt: 'Incident commander mode.',
       skills: ['incident-review'],
     });
@@ -526,13 +526,13 @@ describe('runtime bindings with mock Discord and cron', () => {
       scriptOutput: '1. Example story\n2. Another story',
     });
 
-    expect(fixture.runtime.conversations()).toContainEqual(
+    expect(await fixture.runtime.conversations()).toContainEqual(
       expect.objectContaining({
         id: 'cron:hn-top100-digest',
         agent: 'main',
       }),
     );
-    expect(fixture.runtime.lastAssistantObservation()).toMatchObject({
+    expect(await fixture.runtime.lastAssistantObservation()).toMatchObject({
       toolsets: ['web', 'terminal', 'delegation'],
       delivery: {
         platform: 'discord',
@@ -553,7 +553,7 @@ describe('runtime bindings with mock Discord and cron', () => {
     });
     await fixture.cron.tick('Supplier earnings calendar daily update');
 
-    expect(fixture.runtime.lastAssistantObservation()).toMatchObject({
+    expect(await fixture.runtime.lastAssistantObservation()).toMatchObject({
       skills: ['supplier-research', 'api-change-watchers'],
       toolsets: ['terminal', 'file', 'web'],
       workdir: '/home/user/notes/Work/suppliers',

--- a/packages/discord/src/testing.ts
+++ b/packages/discord/src/testing.ts
@@ -198,11 +198,11 @@ class MockRuntimeFixture {
   readonly discord: MockDiscordConnector;
   readonly cron: MockCronConnector;
   readonly runtime: {
-    conversations: () => MockConversationSummary[];
-    inbox: (conversationId: string) => Array<Record<string, unknown>>;
-    session: (conversationId: string) => unknown;
+    conversations: () => Promise<MockConversationSummary[]>;
+    inbox: (conversationId: string) => Promise<Array<Record<string, unknown>>>;
+    session: (conversationId: string) => Promise<unknown>;
     resume: (conversationId: string) => Promise<void>;
-    lastAssistantObservation: () => unknown;
+    lastAssistantObservation: () => Promise<unknown>;
   };
   readonly effects: {
     entries: () => EffectJournalEntry[];
@@ -221,14 +221,16 @@ class MockRuntimeFixture {
     this.discord.attach((message) => this.handleDiscord(message));
     this.cron.attach((name, payload) => this.handleCron(name, payload));
     this.runtime = {
-      conversations: () =>
-        [...this.store.entries()].map(([id, run]) => ({
+      conversations: async () => {
+        const entries = await this.store.entries();
+        return [...entries].map(([id, run]) => ({
           id,
           agent: run.agentName,
           status: run.status === 'done' ? 'done' : 'suspended',
-        })),
-      inbox: (conversationId) => {
-        const run = this.store.get(conversationId);
+        }));
+      },
+      inbox: async (conversationId) => {
+        const run = await this.store.get(conversationId);
         return (run?.inbox ?? []).map((message) => {
           const attrs = (message.attrs ?? {}) as Record<string, unknown>;
           return {
@@ -241,7 +243,8 @@ class MockRuntimeFixture {
           };
         });
       },
-      session: (conversationId) => this.store.get(conversationId)?.result,
+      session: async (conversationId) =>
+        (await this.store.get(conversationId))?.result,
       resume: async (conversationId) => {
         const result = await this.app.resume(conversationId);
         this.deliverUndelivered(conversationId, result.session.messages);
@@ -367,7 +370,7 @@ class MockRuntimeFixture {
     messages: readonly Message[],
   ): Promise<void> {
     const runContext =
-      (this.store.get(conversationId)?.context as
+      ((await this.store.get(conversationId))?.context as
         | Record<string, unknown>
         | undefined) ?? {};
     const pending = messages
@@ -433,8 +436,9 @@ class MockRuntimeFixture {
     }
   }
 
-  private lastAssistantObservation(): unknown {
-    for (const [, run] of [...this.store.entries()].reverse()) {
+  private async lastAssistantObservation(): Promise<unknown> {
+    const entries = await this.store.entries();
+    for (const [, run] of [...entries].reverse()) {
       const messages = run.result?.messages ?? [];
       for (const message of [...messages].reverse()) {
         if (message.type === 'assistant') {


### PR DESCRIPTION
b0706c8f made DurableRunStore get/has/entries async but packages/discord/src/testing.ts kept calling them synchronously, failing 10 of 16 discord tests with 'store.entries is not iterable'. Async-ifies the MockRuntimeFixture runtime helpers and awaits them in runtime_bindings_mock.test.ts. discord 16/16 and cron 3/3 now pass.