### PR TITLE
fix: per-run serialization for the direct app API

### DIFF
--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -1017,6 +1017,97 @@ describe('checkpoint app runtime', () => {
       'seen:1',
     ]);
   });
+
+  it('serializes concurrent sends to the same runId without racing the cursor', async () => {
+    const delay = (ms: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, ms));
+    // A slow assistant keeps each resume in flight long enough that two
+    // concurrent sends overlap; without per-run serialization they race on the
+    // shared graph cursor / inbox / session and lose or double-consume input.
+    const assistant = Agent.create('slow-echo')
+      .awaitInput('input')
+      .assistant('reply', async (session) => {
+        await delay(20);
+        return `reply:${session.getLastMessage()?.content}`;
+      });
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { slow: assistant },
+      store,
+    });
+
+    const first = await app.run({
+      agent: 'slow',
+      runId: 'run-race',
+      checkpoint: true,
+    });
+    expect(first.status).toBe('suspended');
+
+    await Promise.all([
+      app.send({ runId: 'run-race', input: 'A' }),
+      app.send({ runId: 'run-race', input: 'B' }),
+    ]);
+
+    const finalRun = await store.get('run-race');
+    const contents = (finalRun?.result?.messages ?? []).map(
+      (message) => message.content,
+    );
+    const userContents = (finalRun?.result?.messages ?? [])
+      .filter((message) => message.type === 'user')
+      .map((message) => message.content);
+
+    // Both inputs must be consumed exactly once and both replies retained.
+    expect(userContents.sort()).toEqual(['A', 'B']);
+    expect(contents.filter((content) => content === 'reply:A')).toHaveLength(1);
+    expect(contents.filter((content) => content === 'reply:B')).toHaveLength(1);
+    expect(contents).toHaveLength(4);
+  });
+
+  it('runs sends for different runIds concurrently', async () => {
+    let entered = 0;
+    let releaseAll: () => void = () => undefined;
+    const bothEntered = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+    // Each send blocks until two runs are simultaneously in flight. Distinct
+    // runIds must not serialize, so both must enter before either is released;
+    // if the lock over-serialized, only one would enter and this would hang.
+    const assistant = Agent.create('gated')
+      .awaitInput('input')
+      .assistant('reply', async () => {
+        entered += 1;
+        if (entered === 2) {
+          releaseAll();
+        }
+        await bothEntered;
+        return 'ok';
+      });
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { gated: assistant },
+      store,
+    });
+
+    await app.run({ agent: 'gated', runId: 'run-a', checkpoint: true });
+    await app.run({ agent: 'gated', runId: 'run-b', checkpoint: true });
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('different runIds did not run concurrently')),
+        1000,
+      ),
+    );
+    const results = await Promise.race([
+      Promise.all([
+        app.send({ runId: 'run-a', input: 'a' }),
+        app.send({ runId: 'run-b', input: 'b' }),
+      ]),
+      timeout,
+    ]);
+
+    expect(results.map((result) => result.status)).toEqual(['done', 'done']);
+    expect(entered).toBe(2);
+  });
 });
 
 async function resolveUntilPendingWrite(

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -42,6 +42,7 @@ import {
   type AgentGraphManifest,
 } from './graph';
 import type { ProviderSessionBinding } from './provider_session';
+import { KeyedMutex } from './utils';
 import type { Agent } from './templates/agent';
 import {
   beginCheckpointGraphExecution,
@@ -398,6 +399,12 @@ export class PromptTrailApp {
     | undefined;
   private runtimeServer?: RuntimeServer;
   private runCounter = 0;
+  // Serializes send/resume/run for the same runId so concurrent callers (direct
+  // API and the gateway path) do not race on the graph cursor, inbox, or session
+  // deltas. Distinct runIds still run concurrently. This is process-local; it
+  // composes with (nests inside) RuntimeServer's conversation lock but is a
+  // separate map, so there is no cross-lock ordering to deadlock on.
+  private readonly runLocks = new KeyedMutex();
   // Event idempotency keys embed this sequence, so it must stay monotonic
   // across resumes of the same run within this process — the lifetime of the
   // in-memory delivery-binding stores that dedupe on those keys. It is not
@@ -673,7 +680,12 @@ export class PromptTrailApp {
   async run<TVars extends Vars = Vars>(
     options: PromptTrailRunOptions<TVars>,
   ): Promise<DurableRunResult<TVars>> {
-    return this.startRun(options);
+    // A run without an explicit runId gets a freshly generated id, so no other
+    // caller can contend for it; only lock when the caller pins the runId.
+    if (options.runId === undefined) {
+      return this.startRun(options);
+    }
+    return this.runLocks.run(options.runId, () => this.startRun(options));
   }
 
   async executeCheckpointRun<TVars extends Vars = Vars>(options: {
@@ -715,6 +727,14 @@ export class PromptTrailApp {
   async send<TVars extends Vars = Vars>(
     options: PromptTrailSendOptions,
   ): Promise<DurableRunResult<TVars>> {
+    return this.runLocks.run(options.runId, () =>
+      this.sendImpl<TVars>(options),
+    );
+  }
+
+  private async sendImpl<TVars extends Vars = Vars>(
+    options: PromptTrailSendOptions,
+  ): Promise<DurableRunResult<TVars>> {
     const checkpoint =
       options.checkpoint ??
       (options.resumable ? true : undefined) ??
@@ -749,10 +769,16 @@ export class PromptTrailApp {
       );
     }
     await this.append(options.runId, normalizeInbound(options.input));
-    return this.resume<TVars>(options.runId);
+    return this.resumeImpl<TVars>(options.runId);
   }
 
   async resume<TVars extends Vars = Vars>(
+    runId: string,
+  ): Promise<DurableRunResult<TVars>> {
+    return this.runLocks.run(runId, () => this.resumeImpl<TVars>(runId));
+  }
+
+  private async resumeImpl<TVars extends Vars = Vars>(
     runId: string,
   ): Promise<DurableRunResult<TVars>> {
     const run = await this.getRun<TVars>(runId);
@@ -982,7 +1008,7 @@ export class PromptTrailApp {
       if (options.input !== undefined) {
         await this.append(runId, normalizeInbound(options.input));
       }
-      return this.resume<TVars>(runId);
+      return this.resumeImpl<TVars>(runId);
     }
     return this.executeAgentRun(agent, options);
   }

--- a/packages/core/src/runtime_server.ts
+++ b/packages/core/src/runtime_server.ts
@@ -21,6 +21,7 @@ import {
   type RuntimeDispatchResult,
 } from './runtime_dispatch';
 import type { RuntimeBundle } from './runtime_bindings';
+import { KeyedMutex } from './utils';
 
 export interface RuntimePresence {
   kind: string;
@@ -135,7 +136,7 @@ export class RuntimeServer {
   private readonly observerBus: ObserverBus;
   private readonly runtimeObservers: ObserverLike[];
   private readonly runtimeObserverDisposers: Array<() => void> = [];
-  private readonly conversationLocks = new Map<string, Promise<void>>();
+  private readonly conversationLocks = new KeyedMutex();
   private readonly gateways: RuntimeGatewayDriver[] = [];
   private readonly deliveries = new Map<string, RuntimeDeliveryDriver>();
   private readonly presences = new Map<string, RuntimePresenceDriver>();
@@ -201,7 +202,7 @@ export class RuntimeServer {
 
     const delivery = resolveRuntimeDelivery(defaults.delivery, binding, event);
     const conversationId = binding.conversation(event);
-    await this.withConversationLock(conversationId, async () => {
+    await this.conversationLocks.run(conversationId, async () => {
       const presenceHandle = await this.startPresence(event, delivery);
 
       try {
@@ -232,31 +233,6 @@ export class RuntimeServer {
         await presenceHandle?.stop();
       }
     });
-  }
-
-  private async withConversationLock<T>(
-    conversationId: string,
-    fn: () => Promise<T>,
-  ): Promise<T> {
-    const previous = this.conversationLocks.get(conversationId);
-    let releaseCurrent: () => void = () => undefined;
-    const current = new Promise<void>((resolve) => {
-      releaseCurrent = resolve;
-    });
-    const chain = (previous ?? Promise.resolve())
-      .catch(() => undefined)
-      .then(() => current);
-    this.conversationLocks.set(conversationId, chain);
-
-    await previous?.catch(() => undefined);
-    try {
-      return await fn();
-    } finally {
-      releaseCurrent();
-      if (this.conversationLocks.get(conversationId) === chain) {
-        this.conversationLocks.delete(conversationId);
-      }
-    }
   }
 
   private registerRuntimeObservers(): void {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './keyed_mutex';
 export * from './template_interpolation';

--- a/packages/core/src/utils/keyed_mutex.ts
+++ b/packages/core/src/utils/keyed_mutex.ts
@@ -1,0 +1,33 @@
+/**
+ * Serializes async work by key using a per-key promise chain.
+ *
+ * Each key holds the tail of a promise chain; a new task links after the
+ * current tail and becomes the new tail, so tasks for the same key run one at a
+ * time in submission order. Distinct keys never block each other. The map entry
+ * is deleted once its chain drains so the map does not grow unbounded.
+ */
+export class KeyedMutex {
+  private readonly locks = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(key);
+    let releaseCurrent: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      releaseCurrent = resolve;
+    });
+    const chain = (previous ?? Promise.resolve())
+      .catch(() => undefined)
+      .then(() => current);
+    this.locks.set(key, chain);
+
+    await previous?.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      releaseCurrent();
+      if (this.locks.get(key) === chain) {
+        this.locks.delete(key);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two concurrent `app.send()` calls for the same runId raced in beginCheckpointGraphExecution (optimistic cursor advance + persist) and could silently drop an inbound message — reproduced deterministically in the new test (input 'B' lost with the lock neutered).

- New `KeyedMutex` (extracted from RuntimeServer's withConversationLock, incl. map-entry cleanup so it stays bounded)
- `send`/`resume`/`run` acquire it per runId; bodies moved to sendImpl/resumeImpl so internal composition never re-acquires (no self-deadlock); `run` without an explicit runId skips locking (generated id has no contender)
- RuntimeServer now uses the shared KeyedMutex (no behavior change)
- Tests: same-runId serialization (fails pre-fix), distinct-runId concurrency barrier (guards against over-locking), runtime_server suite green (composed locks, no deadlock)

core: typecheck green, 724 unit tests pass.