### PR TITLE
fix: checkpoint error rollback restores the full entry point and surfaces rollback failures

### DIFF
--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CheckpointRollbackError,
   createCheckpointOnceBoundary,
   createCheckpointOnceMemoStore,
 } from '../../checkpoint_continuation';
-import { PromptTrail, manualGateway, memoryStore } from '../../durable';
+import {
+  MemoryRunStore,
+  PromptTrail,
+  manualGateway,
+  memoryStore,
+} from '../../durable';
 import type {
   AssistantDeliveryOutboxEntry,
   DurableRunStore,
@@ -814,6 +820,182 @@ describe('checkpoint app runtime', () => {
         (message: { content: string }) => message.content,
       ),
     ).toEqual(['redacted', 'continue', 'done']);
+  });
+
+  it('rolls the checkpoint back to a consistent point when a node throws after appending a message', async () => {
+    const store = memoryStore();
+    let fail = true;
+    const assistant = Agent.create('rollback')
+      .inbox('in')
+      .assistant('reply', Source.literal('ok'))
+      .transform('boom', (session) => {
+        if (fail) {
+          throw new Error('boom');
+        }
+        return session;
+      });
+    const app = PromptTrail.app({ agents: { rollback: assistant }, store });
+
+    await expect(
+      app.run({
+        agent: 'rollback',
+        runId: 'run-rollback',
+        input: 'hello',
+        checkpoint: true,
+      }),
+    ).rejects.toThrow('boom');
+
+    // At rest after the error the persisted cursor and session must agree on how
+    // much of the inbox has been consumed: nothing was durably consumed.
+    const afterError = await store.get('run-rollback');
+    expect(afterError?.graphCursor).toBe(0);
+    expect(
+      afterError?.result?.messages.map((message) => message.content) ?? [],
+    ).toEqual([]);
+
+    // A retry replays the (still unconsumed) inbox against the entry-point
+    // session, so the message is not duplicated.
+    fail = false;
+    const retry = await app.resume('run-rollback');
+    expect(retry.status).toBe('done');
+    expect(retry.session.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ok',
+    ]);
+  });
+
+  it('rolls back to a consistent point after an error on a continuation and does not duplicate input', async () => {
+    const store = memoryStore();
+    let fail = false;
+    const assistant = Agent.create('rollback-cont')
+      .inbox('in')
+      .assistant('reply', Source.literal('ok'))
+      .transform('boom', (session) => {
+        if (fail) {
+          throw new Error('boom');
+        }
+        return session;
+      });
+    const app = PromptTrail.app({ agents: { rollback: assistant }, store });
+
+    const first = await app.run({
+      agent: 'rollback',
+      runId: 'run-rollback-cont',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(first.session.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ok',
+    ]);
+
+    fail = true;
+    await expect(
+      app.send({ runId: 'run-rollback-cont', input: 'world' }),
+    ).rejects.toThrow('boom');
+
+    // The prior completion is preserved (consumed 'hello'), the cursor points at
+    // 'world' as the next unconsumed input, and 'world' is not yet in the
+    // session — cursor and session stay mutually consistent.
+    const afterError = await store.get('run-rollback-cont');
+    expect(afterError?.graphCursor).toBe(1);
+    expect(
+      afterError?.result?.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ok']);
+
+    fail = false;
+    const retry = await app.resume('run-rollback-cont');
+    expect(retry.session.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ok',
+      'world',
+      'ok',
+    ]);
+  });
+
+  it('a fresh app instance sharing the store retries a failed run consistently', async () => {
+    const store = memoryStore();
+    let fail = true;
+    const build = () =>
+      Agent.create('cold')
+        .inbox('in')
+        .assistant('reply', Source.literal('ok'))
+        .transform('boom', (session) => {
+          if (fail) {
+            throw new Error('boom');
+          }
+          return session;
+        });
+
+    const app = PromptTrail.app({ agents: { cold: build() }, store });
+    await expect(
+      app.run({
+        agent: 'cold',
+        runId: 'run-cold',
+        input: 'hello',
+        checkpoint: true,
+      }),
+    ).rejects.toThrow('boom');
+
+    // A fresh app instance (cold restart) rebinds the agent and shares the store
+    // but has an empty in-memory session baseline.
+    fail = false;
+    const restarted = PromptTrail.app({ agents: { cold: build() }, store });
+    const retry = await restarted.resume('run-cold');
+    expect(retry.status).toBe('done');
+    expect(retry.session.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ok',
+    ]);
+  });
+
+  it('surfaces both the run error and the rollback error when rollback persistence fails', async () => {
+    class RollbackFailStore extends MemoryRunStore {
+      private advanced = false;
+      async patch(
+        runId: string,
+        patch: Parameters<MemoryRunStore['patch']>[1],
+      ): Promise<void> {
+        if (patch.graphCursor === 1) {
+          this.advanced = true;
+        }
+        // Fail only the rewind write (cursor regressing to 0 after advancing).
+        if (this.advanced && patch.graphCursor === 0) {
+          throw new Error('store patch failed');
+        }
+        return super.patch(runId, patch);
+      }
+    }
+
+    const store = new RollbackFailStore();
+    const assistant = Agent.create('rollback-fail')
+      .inbox('in')
+      .assistant('reply', Source.literal('ok'))
+      .transform('boom', () => {
+        throw new Error('boom');
+      });
+    const app = PromptTrail.app({ agents: { rollback: assistant }, store });
+
+    let caught: unknown;
+    try {
+      await app.run({
+        agent: 'rollback',
+        runId: 'run-rollback-fail',
+        input: 'hello',
+        checkpoint: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CheckpointRollbackError);
+    const rollback = caught as CheckpointRollbackError;
+    expect((rollback.runError as Error).message).toBe('boom');
+    expect((rollback.rollbackError as Error).message).toBe(
+      'store patch failed',
+    );
+    // The original run error is preserved as the cause chain.
+    expect((rollback.cause as Error).message).toBe('boom');
   });
 
   it('uses resolved keyed declarations as the checkpoint tool once dep', async () => {

--- a/packages/core/src/checkpoint_continuation.ts
+++ b/packages/core/src/checkpoint_continuation.ts
@@ -65,6 +65,17 @@ export interface CheckpointGraphExecutionStart<TVars extends Vars, TInbound> {
  * so retries can reuse the recorded value when the store has it; effective-once
  * still requires the remote system to deduplicate by the declared idempotency
  * key. Repeatable effects deliberately bypass this memo.
+ *
+ * Error rollback invariant: the persisted `(graphCursor, session)` pair MUST
+ * stay mutually consistent at rest — both must agree on how much of the inbox
+ * has been consumed. The cursor is advanced optimistically before the graph
+ * runs, so a non-suspend error must discard the whole attempt via
+ * {@link restoreCheckpointGraphEntryPoint}, resetting the cursor, the session,
+ * and the suspension coordinate to the entry point captured here. Otherwise a
+ * retry would replay already-consumed inbox messages against an advanced
+ * session and duplicate them. A suspension is NOT a failure and never rolls
+ * back. If the rollback persist itself fails, both the original run error and
+ * the rollback error are surfaced together via {@link CheckpointRollbackError}.
  */
 export async function beginCheckpointGraphExecution<
   TVars extends Vars,
@@ -186,16 +197,57 @@ export async function recordCheckpointGraphSuspension<
   await persist();
 }
 
-export async function restoreCheckpointGraphCursor<
+/**
+ * Error raised when a checkpoint rollback cannot be persisted after a run
+ * error. Both the original run error and the rollback error are retained so
+ * neither is lost: `cause` and `runError` carry the original failure that
+ * triggered the rollback, `rollbackError` carries the persist failure.
+ */
+export class CheckpointRollbackError extends Error {
+  readonly cause: unknown;
+  constructor(
+    readonly runError: unknown,
+    readonly rollbackError: unknown,
+  ) {
+    super(
+      `Failed to persist checkpoint rollback after a run error. ` +
+        `Rollback error: ${describeError(rollbackError)}. ` +
+        `Original run error: ${describeError(runError)}.`,
+    );
+    this.name = 'CheckpointRollbackError';
+    this.cause = runError;
+  }
+}
+
+/**
+ * Rolls a run's mutable checkpoint state back to the entry point captured by
+ * {@link beginCheckpointGraphExecution} after a non-suspend error, keeping the
+ * persisted `(graphCursor, session)` pair mutually consistent (see the module
+ * doc comment). The failed attempt is discarded wholesale: the inbox cursor,
+ * the session, and the suspension coordinate are all reset to their pre-attempt
+ * values so a retry re-runs from a consistent point. Keyed effects still dedupe
+ * via the once memo and deliveries via the outbox, so at-least-once semantics
+ * survive the rollback.
+ */
+export async function restoreCheckpointGraphEntryPoint<
   TVars extends Vars,
   TInbound,
 >(
   run: CheckpointGraphRunState<TVars, TInbound>,
-  cursor: number,
+  entry: CheckpointGraphExecutionStart<TVars, TInbound>,
   persist: () => Promise<void>,
 ): Promise<void> {
-  run.graphCursor = cursor;
+  run.graphCursor = entry.cursor;
+  run.graphSuspendedAt = entry.resumeFromNode;
+  run.result = entry.isContinuation ? entry.session : undefined;
   await persist();
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }
 
 export function createCheckpointOnceMemoStore(): CheckpointOnceMemoStore {

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -53,7 +53,8 @@ import {
   graphHasInboundConsumer,
   recordCheckpointGraphCompletion,
   recordCheckpointGraphSuspension,
-  restoreCheckpointGraphCursor,
+  restoreCheckpointGraphEntryPoint,
+  CheckpointRollbackError,
   type CheckpointOnceBoundary,
   type CheckpointOnceMemoEntry,
   type CheckpointOnceMemoStore,
@@ -1175,9 +1176,13 @@ export class PromptTrailApp {
           session,
         };
       }
-      await restoreCheckpointGraphCursor(run, checkpoint.cursor, () =>
-        this.persistRun(runId, run),
-      );
+      try {
+        await restoreCheckpointGraphEntryPoint(run, checkpoint, () =>
+          this.persistRun(runId, run),
+        );
+      } catch (rollbackError) {
+        throw new CheckpointRollbackError(error, rollbackError);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
Investigating the suspected 'cursor rewound but session advanced' corruption showed the premise was wrong: run.result is only written at completion/suspension boundaries, so error+retry does not duplicate messages today (regression guards added to keep it that way, incl. a true cold-restart test with a fresh app instance sharing the store).

The genuine defects fixed:
- rollback restored only the cursor; now restoreCheckpointGraphEntryPoint restores cursor + session + suspension coordinate, making the (graphCursor, session) at-rest consistency explicit instead of incidental
- a rollback-persist failure masked the original run error and left state inconsistent; CheckpointRollbackError now carries both (cause-chained)

Residual (tracked separately): a hard crash mid-execution bypasses the error handler while the cursor was optimistically advanced — cold restart can skip unprocessed inputs. Needs cursor-persistence tied to actual consumption or the lease/fencing work.

core: typecheck green, 728 unit tests pass (+4).