### PR TITLE
feat: PromptTrailApp.delete + runtime map pruning + cold-restart tests

### DIFF
--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -949,6 +949,128 @@ describe('checkpoint app runtime', () => {
     ]);
   });
 
+  it('delete removes the run from the store and prunes the process-local maps', async () => {
+    const store = memoryStore();
+    const assistant = Agent.create('deletable')
+      .assistant('reply', () => 'hello')
+      .awaitInput('input');
+    const app = PromptTrail.app({ agents: { deletable: assistant }, store });
+
+    const first = await app.run({
+      agent: 'deletable',
+      runId: 'run-delete',
+      checkpoint: true,
+    });
+    expect(first.status).toBe('suspended');
+
+    // The maps keyed by runId hold entries for a live run: the event sequence
+    // (populated as the graph emits events) and the persisted-session baseline.
+    const internals = app as unknown as {
+      runEventSeqs: Map<string, unknown>;
+      persistedSessions: Map<string, unknown>;
+    };
+    expect(internals.runEventSeqs.has('run-delete')).toBe(true);
+    expect(internals.persistedSessions.has('run-delete')).toBe(true);
+    expect(await store.get('run-delete')).toBeDefined();
+
+    await app.delete('run-delete');
+
+    expect(await store.get('run-delete')).toBeUndefined();
+    expect(internals.runEventSeqs.has('run-delete')).toBe(false);
+    expect(internals.persistedSessions.has('run-delete')).toBe(false);
+  });
+
+  it('resumes an awaitInput suspension in a fresh app instance without duplicating prompts', async () => {
+    const store = memoryStore();
+    const build = () =>
+      Agent.create('cold-suspend')
+        .system('sys', 'System')
+        .assistant('greet', Source.literal('hello'))
+        .awaitInput('input')
+        .assistant(
+          'reply',
+          (session) => `reply:${session.getLastMessage()?.content}`,
+        );
+
+    const app = PromptTrail.app({ agents: { cold: build() }, store });
+    const first = await app.run({
+      agent: 'cold',
+      runId: 'run-cold-suspend',
+      checkpoint: true,
+    });
+    expect(first.status).toBe('suspended');
+
+    // A fresh app instance (cold restart) shares the store but starts with empty
+    // in-memory session/event baselines. Sending the awaited input must resume
+    // to completion with the correct message order and no duplicated prompt.
+    const restarted = PromptTrail.app({ agents: { cold: build() }, store });
+    const resumed = await restarted.send({
+      runId: 'run-cold-suspend',
+      input: 'world',
+    });
+
+    expect(resumed.status).toBe('done');
+    expect(resumed.session.messages.map((message) => message.content)).toEqual([
+      'System',
+      'hello',
+      'world',
+      'reply:world',
+    ]);
+    expect(
+      resumed.session.messages.filter((message) => message.content === 'hello'),
+    ).toHaveLength(1);
+  });
+
+  it('does not re-execute a keyed effect after cold restart resume', async () => {
+    const store = memoryStore();
+    let executions = 0;
+    const build = () =>
+      Agent.create('cold-once')
+        .tool('write', {
+          kind: 'tool',
+          name: 'write',
+          description: 'Write.',
+          inputSchema: {
+            parse: (input: unknown) => input,
+          } as any,
+          effect: { idempotencyKey: 'write:cold' },
+          execute: () => {
+            executions++;
+            return 'written';
+          },
+        })
+        .assistant('call', () => ({
+          content: 'need write',
+          toolCalls: [{ id: 'call-1', name: 'write', arguments: {} }],
+        }))
+        .tools('run')
+        .awaitInput('input')
+        .assistant('after', () => 'done');
+
+    const app = PromptTrail.app({ agents: { cold: build() }, store });
+    const first = await app.run({
+      agent: 'cold',
+      runId: 'run-cold-once',
+      checkpoint: true,
+    });
+    expect(first.status).toBe('suspended');
+    // The keyed effect ran once in instance A before the suspension, and its
+    // once memo is recorded in the shared store.
+    expect(executions).toBe(1);
+
+    // Resuming in a fresh instance (empty in-memory once boundary) must consult
+    // the store's once memo and must not re-run the effect body.
+    const restarted = PromptTrail.app({ agents: { cold: build() }, store });
+    const resumed = await restarted.send({
+      runId: 'run-cold-once',
+      input: 'go',
+    });
+
+    expect(resumed.status).toBe('done');
+    expect(executions).toBe(1);
+    expect(resumed.session.getLastMessage()?.content).toBe('done');
+  });
+
   it('surfaces both the run error and the rollback error when rollback persistence fails', async () => {
     class RollbackFailStore extends MemoryRunStore {
       private advanced = false;

--- a/packages/core/src/__tests__/unit/runtime_server.test.ts
+++ b/packages/core/src/__tests__/unit/runtime_server.test.ts
@@ -2079,6 +2079,87 @@ describe('RuntimeServer', () => {
     ).toEqual([{ status: 'delivered', attempts: 2, lastError: undefined }]);
   });
 
+  it('does not re-deliver a completed delivery after cold restart', async () => {
+    const deliveries: string[] = [];
+    const main = Agent.create('main').assistant('reply', () => 'stored reply');
+    const bundle = PromptTrail.runtimeBundle({
+      name: 'server-outbox-delivered-cold-restart-test',
+      agents: { main },
+      defaults: { checkpoint: true },
+      bindings: [],
+    });
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      store,
+      agents: bundle.agents,
+    });
+    const runId = 'fake-chat:guild:workroom:channel:C_general';
+    const target = fakeChat.channel('general');
+    const deliveryKey = assistantDeliveryKey(runId, 0, target);
+    await app.run({
+      agent: 'main',
+      runId,
+      checkpoint: true,
+    });
+    await app.prepareAssistantDeliveries(runId, [
+      {
+        assistantIndex: 0,
+        idempotencyKey: deliveryKey,
+        message: {
+          type: 'assistant',
+          content: 'already delivered',
+        },
+        target,
+      },
+    ]);
+    // Instance A completes the delivery.
+    await app.markAssistantDelivery(runId, deliveryKey, 'delivering');
+    await app.markAssistantDelivery(
+      runId,
+      deliveryKey,
+      'delivered',
+      undefined,
+      {
+        messageId: 'first',
+      },
+    );
+
+    // A fresh app + server instance (cold restart) shares the same store. On
+    // start it scans the outbox for pending retries; a delivered entry must not
+    // be re-delivered.
+    const restarted = PromptTrail.app({
+      store,
+      agents: bundle.agents,
+    });
+    const server = PromptTrail.server({
+      bundle,
+      runtime: restarted,
+      adapters: [
+        {
+          name: 'test-fake-chat',
+          deliveries: [
+            {
+              platform: 'fake-chat',
+              deliver(ctx, _target, message) {
+                deliveries.push(`${ctx.idempotencyKey}:${message.content}`);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await server.start();
+
+    expect(deliveries).toEqual([]);
+    expect(
+      (await restarted.assistantDeliveryOutbox(runId)).map((entry) => ({
+        status: entry.status,
+        attempts: entry.attempts,
+      })),
+    ).toEqual([{ status: 'delivered', attempts: 1 }]);
+  });
+
   it('stops startup delivery retries for a conversation after the first failure', async () => {
     const order: string[] = [];
     const main = Agent.create('main').assistant('reply', () => 'stored reply');

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -779,6 +779,27 @@ export class PromptTrailApp {
     return this.runLocks.run(runId, () => this.resumeImpl<TVars>(runId));
   }
 
+  /**
+   * Deletes a run from the store and prunes the process-local maps keyed by
+   * runId so they do not grow unboundedly across a long-lived process.
+   *
+   * Pruning happens only on delete, never on completion: a completed run whose
+   * graph has an inbound consumer can still be continued via `send` (which
+   * flips status back to `open` and resumes), and continuation relies on
+   * `runEventSeqs` staying monotonic and `persistedSessions` holding the delta
+   * baseline. Once the run is deleted those invariants no longer matter.
+   *
+   * Acquires the per-run mutex so a delete cannot interleave with an in-flight
+   * send/resume/run for the same runId.
+   */
+  async delete(runId: string): Promise<void> {
+    await this.runLocks.run(runId, async () => {
+      await this.store.delete(runId);
+      this.runEventSeqs.delete(runId);
+      this.persistedSessions.delete(runId);
+    });
+  }
+
   private async resumeImpl<TVars extends Vars = Vars>(
     runId: string,
   ): Promise<DurableRunResult<TVars>> {

--- a/packages/core/src/runtime_server.ts
+++ b/packages/core/src/runtime_server.ts
@@ -140,6 +140,16 @@ export class RuntimeServer {
   private readonly gateways: RuntimeGatewayDriver[] = [];
   private readonly deliveries = new Map<string, RuntimeDeliveryDriver>();
   private readonly presences = new Map<string, RuntimePresenceDriver>();
+  // Monotonic delivery-event sequence per conversation, process-local for the
+  // lifetime of this server instance. Intentionally NOT pruned or LRU-capped:
+  // RuntimeServer has no end-of-conversation signal (conversations can always
+  // resume), and evicting an entry would rewind its seq to 0. Because these seq
+  // values feed the ordering of delivery events consumed by the in-memory
+  // delivery-binding/observer dedupe stores, a rewind could collide with or
+  // reorder events already emitted for a still-live conversation. Growth is
+  // bounded by the number of distinct conversations a single process handles,
+  // matching the lifetime of those dedupe stores, so leaving it unbounded is
+  // the correct trade-off over a cap that risks correctness.
   private readonly eventSeqByConversation = new Map<string, number>();
 
   constructor(private readonly options: RuntimeServerOptions) {


### PR DESCRIPTION
Part of the durable-runtime hardening series (#51, #53).

- New `PromptTrailApp.delete(runId)`: the app had no delete API, so nothing ever pruned the process-lifetime `runEventSeqs`/`persistedSessions` maps. Delete now removes the stored run and prunes both under the per-run KeyedMutex.
- Pruning is delete-only by design: a done run can be continued (append flips it back to open), and continuation depends on monotonic event seqs + the persisted-session baseline. Verified against the continuation path.
- `eventSeqByConversation` documented as intentionally unbounded (no safe pruning point; eviction would rewind delivery-dedupe seqs).
- Cold-restart tests (fresh app instance, shared store): awaitInput suspend/resume, keyed-effect once-memo honored cold, completed deliveries not re-sent — all pass, no bugs found.

core: typecheck green, 732 unit tests (+4).