### PR TITLE
fix: atomic seq allocation in SQL stores + explicit concurrency contract

### DIFF
--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -212,6 +212,31 @@ export interface AppGateway {
   stop?(): Promise<void> | void;
 }
 
+/**
+ * Concurrency contract:
+ *
+ * - This store family currently assumes a SINGLE WRITER PER RUN. Within one
+ *   process, `PromptTrailApp` provides that guarantee itself: every
+ *   `run`/`send`/`resume`/`delete` call for a given `runId` is serialized
+ *   through a per-run mutex (`KeyedMutex`), so a backend never sees two
+ *   concurrent writes for the same run from that process. Cross-process
+ *   single-writer enforcement (e.g. multiple app instances pointed at the
+ *   same store) is NOT yet provided by any backend here — it arrives with the
+ *   planned single-writer lease (durability roadmap §2). Until then, running
+ *   more than one process against the same store for the same `runId` is
+ *   unsupported and may corrupt per-run sequencing.
+ * - What IS guaranteed today, and must be preserved by any backend: seq/offset
+ *   allocation (e.g. `appendSessionDelta`'s `seq`, `appendInbox`'s offset
+ *   idempotency) must be atomic and correct under concurrent appends to
+ *   DIFFERENT runs sharing the same store/connection pool. A backend must
+ *   not compute "next seq" via a separate read-then-write round trip that
+ *   could interleave with unrelated work on the same pool/connection in a way
+ *   that corrupts another run's data; prefer a single atomic statement (e.g.
+ *   `INSERT ... SELECT COALESCE(MAX(seq) + 1, 0) ... WHERE run_id = ?`) or an
+ *   explicit transaction. Concurrent appends to the SAME run are out of
+ *   contract per the single-writer assumption above and are not required to
+ *   be race-free.
+ */
 export interface DurableRunStore {
   /**
    * Reads are now async so networked store backends (Postgres, Redis, libsql)

--- a/packages/store-conformance/src/index.ts
+++ b/packages/store-conformance/src/index.ts
@@ -544,5 +544,69 @@ export function runDurableRunStoreConformance(spec: ConformanceSpec): void {
         (effective.vars as Record<string, unknown>)['leaked'],
       ).toBeUndefined();
     });
+
+    // Case 14: CONCURRENCY — N concurrent appendSessionDelta chains to N
+    // DIFFERENT runs on the same store all succeed with correct, independent
+    // per-run seq chains. This is the concurrency contract a backend must
+    // honor (see DurableRunStore's docstring in packages/core/src/durable.ts):
+    // seq/offset allocation must be atomic and correct across concurrent
+    // activity on DIFFERENT runs sharing one store/connection pool. It does
+    // NOT test concurrent appends to the SAME run — that is out of contract
+    // (single-writer-per-run is assumed; the app-level per-run mutex provides
+    // it in-process).
+    it('case 14: concurrent appendSessionDelta chains to different runs stay independent', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+
+      const runCount = 8;
+      const deltasPerRun = 3;
+      const runIds = Array.from(
+        { length: runCount },
+        (_, i) => `run-concurrent-14-${i}`,
+      );
+
+      await Promise.all(
+        runIds.map((runId) =>
+          store.create(runId, makeInitialRun(agent, agentName)),
+        ),
+      );
+
+      // For each run, append `deltasPerRun` deltas IN ORDER (same-run appends
+      // stay sequential, honoring the single-writer-per-run contract), but run
+      // all N runs' append chains CONCURRENTLY with each other so a backend
+      // that allocates seq via a shared/global counter — or that races on the
+      // connection pool across different run_ids — would be exposed.
+      await Promise.all(
+        runIds.map(async (runId) => {
+          for (let i = 0; i < deltasPerRun; i++) {
+            const delta: SessionCheckpointDelta = {
+              fromVersion: i,
+              toVersion: i + 1,
+              appendedMessages: [
+                { type: 'user', content: `${runId}-message-${i}` },
+              ],
+              varsSet: { [`k${i}`]: i },
+            };
+            await store.appendSessionDelta(runId, delta);
+          }
+        }),
+      );
+
+      for (const runId of runIds) {
+        const retrieved = await store.get(runId);
+        expect(retrieved).toBeDefined();
+        const result = retrieved!.result;
+        expect(result).toBeDefined();
+        // Correct per-run seq chain: all deltasPerRun deltas landed, in order,
+        // with no gaps and no cross-run leakage — otherwise version/message
+        // count would be wrong or messages would belong to another run.
+        expect(result!.version).toBe(deltasPerRun);
+        expect(result!.messages).toHaveLength(deltasPerRun);
+        for (let i = 0; i < deltasPerRun; i++) {
+          expect(result!.messages[i].content).toBe(`${runId}-message-${i}`);
+        }
+      }
+    });
   });
 }

--- a/packages/store-libsql/src/index.ts
+++ b/packages/store-libsql/src/index.ts
@@ -198,14 +198,10 @@ export class LibsqlRunStore implements DurableRunStore {
     runId: string,
     delta: SessionCheckpointDelta<any>,
   ): Promise<void> {
-    // Compute the next seq atomically by reading the current MAX.
-    const seqRes = await this.client.execute({
-      sql: `SELECT COALESCE(MAX(seq) + 1, 0) AS seq
-            FROM session_deltas WHERE run_id = ?`,
-      args: [runId],
-    });
-    const seq = seqRes.rows[0][0] as number;
-
+    // Single-statement seq allocation: INSERT ... SELECT COALESCE(MAX(seq)+1, 0)
+    // computes the next seq and inserts in one round trip, so there is no
+    // window between reading the max and writing the row for another
+    // statement on this run to land in.
     await this.client.execute({
       sql: `INSERT INTO session_deltas (
               run_id,
@@ -216,16 +212,18 @@ export class LibsqlRunStore implements DurableRunStore {
               vars_set_json,
               vars_deleted_json,
               rewrite
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            )
+            SELECT ?, COALESCE(MAX(seq) + 1, 0), ?, ?, ?, ?, ?, ?
+            FROM session_deltas WHERE run_id = ?`,
       args: [
         runId,
-        seq,
         delta.fromVersion,
         delta.toVersion,
         JSON.stringify(delta.appendedMessages),
         jsonOrNull(delta.varsSet),
         jsonOrNull(delta.varsDeleted),
         delta.rewrite ? 1 : 0,
+        runId,
       ],
     });
   }

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -220,13 +220,13 @@ export class PostgresRunStore implements DurableRunStore {
   ): Promise<void> {
     const client = await this.pool.connect();
     try {
-      // Compute next seq
-      const seqRes = await client.query(
-        `SELECT COALESCE(MAX(seq) + 1, 0) AS seq FROM session_deltas WHERE run_id = $1`,
-        [runId],
-      );
-      const seq: number = Number((seqRes.rows[0] as { seq: unknown }).seq);
-
+      // Single-statement seq allocation: INSERT ... SELECT COALESCE(MAX(seq)+1, 0)
+      // computes the next seq and inserts in one round trip, so there is no
+      // window between reading the max and writing the row for another
+      // statement on this run to land in. The explicit ::type casts are
+      // required for pg-mem, which (unlike real Postgres) cannot infer
+      // parameter types from the INSERT target columns when they flow through
+      // a SELECT list rather than a VALUES list.
       await client.query(
         `INSERT INTO session_deltas (
           run_id,
@@ -237,10 +237,19 @@ export class PostgresRunStore implements DurableRunStore {
           vars_set_json,
           vars_deleted_json,
           rewrite
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        )
+        SELECT
+          $1::text,
+          COALESCE(MAX(seq) + 1, 0),
+          $2::integer,
+          $3::integer,
+          $4::text,
+          $5::text,
+          $6::text,
+          $7::integer
+        FROM session_deltas WHERE run_id = $1::text`,
         [
           runId,
-          seq,
           delta.fromVersion,
           delta.toVersion,
           JSON.stringify(delta.appendedMessages),


### PR DESCRIPTION
postgres/libsql allocated delta seq via SELECT MAX(seq)+1 followed by a separate INSERT — two round trips that interleave under a shared pool. Collapsed to a single INSERT…SELECT COALESCE(MAX(seq)+1,0) per backend (pg-mem required explicit ::casts on params in the SELECT list).

Also documents the DurableRunStore concurrency contract (single writer per run; atomic allocation across different runs) and adds conformance case 14 exercising N concurrent per-run chains against all five backend specs.

store tests: sqlite 28, postgres/libsql/redis 14 each — green; typechecks clean.