### PR TITLE
feat: real cron scheduler (claw roadmap #3)

### DIFF
--- a/packages/core/src/__tests__/unit/runtime_server.test.ts
+++ b/packages/core/src/__tests__/unit/runtime_server.test.ts
@@ -486,6 +486,52 @@ describe('RuntimeServer', () => {
     ]);
   });
 
+  it('exposes matching bundle bindings to gateways by trigger type', async () => {
+    let gatewayBindings:
+      | RuntimeGatewayContext<FakeMessageEvent>['bindings']
+      | undefined;
+    const main = chatAgent('main', () => 'reply');
+    const bundle = PromptTrail.runtimeBundle({
+      name: 'gateway-bindings-test',
+      agents: { main },
+      bindings: [
+        on(fakeChat.messages())
+          .toAgent('main')
+          .conversation(() => 'fake-chat:one')
+          .name('binding-one'),
+        on({ type: 'other.trigger' })
+          .toAgent('main')
+          .conversation(() => 'other:one'),
+      ],
+    });
+    const server = PromptTrail.server({
+      bundle,
+      runtime: PromptTrail.app({
+        store: memoryStore(),
+        agents: bundle.agents,
+      }),
+      adapters: [
+        {
+          name: 'test-fake-chat',
+          gateways: [
+            {
+              type: 'fake-chat.messages',
+              start(ctx) {
+                gatewayBindings = ctx.bindings;
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await server.start();
+
+    expect(gatewayBindings).toHaveLength(1);
+    expect(gatewayBindings?.[0]?.name).toBe('binding-one');
+    expect(gatewayBindings?.[0]?.trigger.type).toBe('fake-chat.messages');
+  });
+
   it('routes runtime bundle events to registered Agent graphs', async () => {
     const main = Agent.create('main')
       .inbox('inbound')

--- a/packages/core/src/runtime_server.ts
+++ b/packages/core/src/runtime_server.ts
@@ -11,7 +11,11 @@ import {
   type ObserverLike,
 } from './execution';
 import type { Message } from './message';
-import type { DeliveryTarget, TriggerEvent } from './runtime_bindings';
+import type {
+  DeliveryTarget,
+  RuntimeBinding,
+  TriggerEvent,
+} from './runtime_bindings';
 import {
   AssistantDeliveryTracker,
   dispatchRuntimeEvent,
@@ -40,6 +44,12 @@ export interface RuntimeGatewayContext<
   TEvent extends TriggerEvent = TriggerEvent,
 > {
   emit(event: TEvent, options?: RuntimeGatewayEmitOptions): Promise<void>;
+  /**
+   * Bundle bindings whose trigger type matches this gateway's type. Gateways
+   * inspect their own triggers to discover declarative configuration (e.g. cron
+   * schedules) so a schedule is declared exactly once, on the binding.
+   */
+  bindings: readonly RuntimeBinding<TEvent>[];
 }
 
 export interface RuntimeGatewayDriver<
@@ -181,6 +191,7 @@ export class RuntimeServer {
       await gateway.start({
         emit: (event, emitOptions) =>
           this.dispatch(gateway.type, event, emitOptions),
+        bindings: this.bindingsForType(gateway.type),
       });
     }
   }
@@ -243,6 +254,14 @@ export class RuntimeServer {
         await presenceHandle?.stop();
       }
     });
+  }
+
+  private bindingsForType(
+    type: string,
+  ): readonly RuntimeBinding<TriggerEvent>[] {
+    return this.options.bundle.bindings.filter(
+      (binding) => binding.trigger.type === type,
+    );
   }
 
   private registerRuntimeObservers(): void {

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -30,7 +30,8 @@
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },
   "dependencies": {
-    "@prompttrail/core": "workspace:*"
+    "@prompttrail/core": "workspace:*",
+    "croner": "^10.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.19",

--- a/packages/cron/src/__tests__/unit/cron_gateway.test.ts
+++ b/packages/cron/src/__tests__/unit/cron_gateway.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { on, type RuntimeBinding, type TriggerEvent } from '@prompttrail/core';
+import type {
+  RuntimeGatewayContext,
+  RuntimeGatewayEmitOptions,
+} from '@prompttrail/core/runtime_server';
+import { cron, cronGateway, isCronEvent, type CronEvent } from '../../index';
+
+function cronBinding(
+  schedule: string,
+  name?: string,
+): RuntimeBinding<CronEvent> {
+  const builder = on(cron.schedule(schedule))
+    .toAgent('main')
+    .conversation(({ job }) => `cron:${job.id}`);
+  if (name) {
+    builder.name(name);
+  }
+  return builder.build() as unknown as RuntimeBinding<CronEvent>;
+}
+
+function count<T>(values: readonly T[], value: T): number {
+  return values.filter((candidate) => candidate === value).length;
+}
+
+interface CapturedEmit {
+  event: CronEvent;
+  options?: RuntimeGatewayEmitOptions;
+}
+
+function fakeContext(
+  bindings: readonly RuntimeBinding<CronEvent>[],
+  emit: (
+    event: CronEvent,
+    options?: RuntimeGatewayEmitOptions,
+  ) => Promise<void>,
+): RuntimeGatewayContext<CronEvent> {
+  return { bindings, emit };
+}
+
+function startGateway(
+  adapter: ReturnType<typeof cronGateway>,
+  ctx: RuntimeGatewayContext<CronEvent>,
+) {
+  const gateway = adapter.gateways![0]!;
+  void gateway.start(ctx as RuntimeGatewayContext<TriggerEvent>);
+  return gateway;
+}
+
+describe('cronGateway', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires on schedule and emits a valid CronEvent', async () => {
+    const captured: CapturedEmit[] = [];
+    const ctx = fakeContext(
+      [cronBinding('* * * * *', 'Minute digest')],
+      async (event, options) => {
+        captured.push({ event, options });
+      },
+    );
+    startGateway(cronGateway({ timezone: 'UTC' }), ctx);
+
+    // Nothing fires before the first minute boundary.
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(captured).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(captured).toHaveLength(1);
+
+    const { event } = captured[0]!;
+    expect(isCronEvent(event)).toBe(true);
+    expect(event.job).toEqual({
+      id: 'minute-digest',
+      name: 'Minute digest',
+      schedule: '* * * * *',
+    });
+    expect(event.firedAt).toBe('2026-01-01T00:01:00.000Z');
+    expect(event.payload).toEqual({ firedAt: '2026-01-01T00:01:00.000Z' });
+
+    // Re-arms for the following minute.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(captured).toHaveLength(2);
+    expect(captured[1]!.event.firedAt).toBe('2026-01-01T00:02:00.000Z');
+  });
+
+  it('derives a stable job id from the schedule and index when unnamed', async () => {
+    const captured: CronEvent[] = [];
+    const ctx = fakeContext([cronBinding('*/2 * * * *')], async (event) => {
+      captured.push(event);
+    });
+    startGateway(cronGateway({ timezone: 'UTC' }), ctx);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.job.id).toBe('2-0');
+    expect(captured[0]!.job.name).toBe('*/2 * * * *');
+  });
+
+  it('fires multiple schedules independently', async () => {
+    const fires: string[] = [];
+    const ctx = fakeContext(
+      [
+        cronBinding('* * * * *', 'every-minute'),
+        cronBinding('*/2 * * * *', 'every-two-minutes'),
+      ],
+      async (event) => {
+        fires.push(event.job.id);
+      },
+    );
+    startGateway(cronGateway({ timezone: 'UTC' }), ctx);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fires).toEqual(['every-minute']);
+
+    // At the two-minute mark both schedules are due; same-tick fire order is
+    // not guaranteed, so assert per-job counts instead.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(count(fires, 'every-minute')).toBe(2);
+    expect(count(fires, 'every-two-minutes')).toBe(1);
+  });
+
+  it('does not queue overlapping fires for the same job', async () => {
+    let emitCount = 0;
+    let releaseFirst: (() => void) | undefined;
+    const firstEmit = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const ctx = fakeContext(
+      [cronBinding('* * * * *', 'slow-job')],
+      async () => {
+        emitCount += 1;
+        if (emitCount === 1) {
+          await firstEmit;
+        }
+      },
+    );
+    startGateway(cronGateway({ timezone: 'UTC' }), ctx);
+
+    // First fire starts and stays in flight (emit awaits firstEmit).
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(emitCount).toBe(1);
+
+    // Next fire is due but the previous emit has not resolved: skipped.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(emitCount).toBe(1);
+
+    // Once the first emit resolves, subsequent fires emit again.
+    releaseFirst?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(emitCount).toBe(2);
+  });
+
+  it('stops all timers and does not fire after stop', async () => {
+    const captured: CronEvent[] = [];
+    const ctx = fakeContext(
+      [cronBinding('* * * * *', 'job')],
+      async (event) => {
+        captured.push(event);
+      },
+    );
+    const gateway = startGateway(cronGateway({ timezone: 'UTC' }), ctx);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(captured).toHaveLength(1);
+
+    await gateway.stop?.();
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(captured).toHaveLength(1);
+  });
+
+  it('routes emit rejections to onError', async () => {
+    const errors: Array<{ error: unknown; jobId: string }> = [];
+    const ctx = fakeContext([cronBinding('* * * * *', 'boom')], async () => {
+      throw new Error('emit failed');
+    });
+    startGateway(
+      cronGateway({
+        timezone: 'UTC',
+        onError: (error, job) => {
+          errors.push({ error, jobId: job.id });
+        },
+      }),
+      ctx,
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(errors).toHaveLength(1);
+    expect((errors[0]!.error as Error).message).toBe('emit failed');
+    expect(errors[0]!.jobId).toBe('boom');
+
+    // A failed emit clears in-flight state so the next occurrence still fires.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(errors).toHaveLength(2);
+  });
+});

--- a/packages/cron/src/__tests__/unit/cron_gateway_integration.test.ts
+++ b/packages/cron/src/__tests__/unit/cron_gateway_integration.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Agent, PromptTrail, memoryStore } from '@prompttrail/core';
+import { cron, cronGateway } from '../../index';
+
+describe('cronGateway end-to-end', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs a durable agent when a cron schedule fires', async () => {
+    const runs: string[] = [];
+    const main = Agent.create('main')
+      .inbox('inbound')
+      .assistant('reply', (session) => {
+        const content = session.getLastMessage()?.content ?? '';
+        runs.push(content);
+        return `reply:${content}`;
+      });
+
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      store,
+      agents: { main },
+    })
+      .adapter(cronGateway({ timezone: 'UTC' }))
+      .on(cron.schedule('* * * * *'), (binding) =>
+        binding
+          .name('minute digest')
+          .toAgent('main')
+          .conversation(({ job }) => `cron:${job.id}`)
+          .input('run the digest'),
+      );
+
+    await app.start();
+
+    // No fire before the first minute boundary.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runs).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runs).toEqual(['run the digest']);
+
+    const run = await store.get('cron:minute-digest');
+    expect(run?.status).toBe('done');
+    expect(run?.result?.messages.map((message) => message.content)).toContain(
+      'reply:run the digest',
+    );
+
+    await app.stop();
+
+    // After stop, further time does not trigger new runs.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(runs).toEqual(['run the digest']);
+  });
+});

--- a/packages/cron/src/index.ts
+++ b/packages/cron/src/index.ts
@@ -1,4 +1,14 @@
-import type { DeliveryTarget, Trigger, TriggerEvent } from '@prompttrail/core';
+import { Cron } from 'croner';
+import type {
+  DeliveryTarget,
+  RuntimeBinding,
+  Trigger,
+  TriggerEvent,
+} from '@prompttrail/core';
+import type {
+  RuntimeAdapter,
+  RuntimeGatewayContext,
+} from '@prompttrail/core/runtime_server';
 
 export interface CronEvent extends TriggerEvent {
   source: 'cron';
@@ -8,6 +18,8 @@ export interface CronEvent extends TriggerEvent {
     schedule: string;
     origin?: DeliveryTarget;
   };
+  /** ISO timestamp of the moment the scheduler fired this occurrence. */
+  firedAt?: string;
   payload?: Record<string, unknown>;
 }
 
@@ -40,4 +52,153 @@ export function isCronEvent(event: TriggerEvent): event is CronEvent {
     typeof job.id === 'string' &&
     typeof job.name === 'string'
   );
+}
+
+/** Stable job identity derived from a cron binding. */
+export interface CronJob {
+  id: string;
+  name: string;
+  schedule: string;
+}
+
+export interface CronGatewayOptions {
+  /**
+   * IANA timezone applied when computing each schedule's next run. Defaults to
+   * the host's local timezone.
+   */
+  timezone?: string;
+  /** Invoked when a fired job's dispatch (ctx.emit) rejects. */
+  onError?: (error: unknown, job: CronJob) => void | Promise<void>;
+}
+
+const CRON_TRIGGER_TYPE = 'cron.schedule';
+
+/**
+ * Real cron scheduler adapter. Discovers schedules declared on cron bindings
+ * (trigger type 'cron.schedule') via the gateway context, arms one timer per
+ * schedule, and emits a CronEvent on each fire.
+ *
+ * Overlap policy: fires are NOT queued. If a job's previous emit is still
+ * awaiting when its next fire is due, that fire is skipped; the following
+ * occurrence is still armed.
+ */
+export function cronGateway(options: CronGatewayOptions = {}): RuntimeAdapter {
+  let scheduler: CronScheduler | undefined;
+  return {
+    name: 'cron',
+    gateways: [
+      {
+        type: CRON_TRIGGER_TYPE,
+        start(ctx: RuntimeGatewayContext<CronEvent>) {
+          scheduler = new CronScheduler(ctx, options);
+          scheduler.start();
+        },
+        stop() {
+          scheduler?.stop();
+          scheduler = undefined;
+        },
+      },
+    ],
+  };
+}
+
+class CronScheduler {
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+  private readonly inFlight = new Set<string>();
+  private stopped = false;
+
+  constructor(
+    private readonly ctx: RuntimeGatewayContext<CronEvent>,
+    private readonly options: CronGatewayOptions,
+  ) {}
+
+  start(): void {
+    this.ctx.bindings.forEach((binding, index) => {
+      const job = deriveCronJob(binding, index);
+      if (!job) {
+        return;
+      }
+      this.arm(job);
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    for (const timer of this.timers) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+
+  private arm(job: CronJob): void {
+    if (this.stopped) {
+      return;
+    }
+    const pattern = new Cron(job.schedule, { timezone: this.options.timezone });
+    const scheduleNext = () => {
+      if (this.stopped) {
+        return;
+      }
+      const next = pattern.nextRun();
+      if (!next) {
+        return;
+      }
+      const delay = Math.max(0, next.getTime() - Date.now());
+      const timer = setTimeout(() => {
+        this.timers.delete(timer);
+        void this.fire(job);
+        scheduleNext();
+      }, delay);
+      this.timers.add(timer);
+    };
+    scheduleNext();
+  }
+
+  private async fire(job: CronJob): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+    // Overlap policy: skip (do not queue) while the previous emit is in flight.
+    if (this.inFlight.has(job.id)) {
+      return;
+    }
+    this.inFlight.add(job.id);
+    const firedAt = new Date().toISOString();
+    const event: CronEvent = {
+      source: 'cron',
+      job: { id: job.id, name: job.name, schedule: job.schedule },
+      firedAt,
+      payload: { firedAt },
+    };
+    try {
+      await this.ctx.emit(event);
+    } catch (error) {
+      await this.options.onError?.(error, job);
+    } finally {
+      this.inFlight.delete(job.id);
+    }
+  }
+}
+
+function deriveCronJob(
+  binding: RuntimeBinding<CronEvent>,
+  index: number,
+): CronJob | undefined {
+  const schedule = (binding.trigger as CronTrigger).schedule;
+  if (!schedule) {
+    return undefined;
+  }
+  const name = binding.name ?? schedule;
+  const id = binding.name
+    ? slug(binding.name)
+    : `${slug(schedule) || 'cron'}-${index}`;
+  return { id, name, schedule };
+}
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }

--- a/packages/cron/vitest.config.ts
+++ b/packages/cron/vitest.config.ts
@@ -2,10 +2,22 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
-    alias: {
-      '@prompttrail/core': new URL('../core/src/index.ts', import.meta.url)
-        .pathname,
-    },
+    alias: [
+      {
+        find: '@prompttrail/core/runtime_server',
+        replacement: new URL('../core/src/runtime_server.ts', import.meta.url)
+          .pathname,
+      },
+      {
+        find: '@prompttrail/core/runtime_dispatch',
+        replacement: new URL('../core/src/runtime_dispatch.ts', import.meta.url)
+          .pathname,
+      },
+      {
+        find: '@prompttrail/core',
+        replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
+      },
+    ],
   },
   test: {
     globals: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@prompttrail/core':
         specifier: link:../core
         version: link:../core
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
     devDependencies:
       '@types/node':
         specifier: ^20.17.19
@@ -1966,6 +1969,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5886,6 +5893,8 @@ snapshots:
       yaml: 1.10.2
 
   create-require@1.1.1: {}
+
+  croner@10.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
@prompttrail/cron previously exported only the trigger shape — the only way to fire a cron binding was the test mock's manual tick(). This implements the real scheduler:

- `cronGateway(options?)`: RuntimeAdapter that discovers 'cron.schedule' bindings from the RuntimeBundle (schedule declared exactly once, on the binding), arms a timer per job via croner's next-run computation, emits well-formed CronEvents, skips (never queues) overlapping fires, and fully disarms on stop()
- job identity derives from the binding name (slug) or schedule+index; events carry firedAt
- minimal core extension: RuntimeGatewayContext.bindings exposes the gateway-type's bindings
- croner (zero-dep) added to packages/cron

Tests: 6 gateway unit tests (fake timers: fire timing, multi-schedule independence, stop, overlap policy), 1 end-to-end (PromptTrail.app + cron binding + gateway → agent run executes), 1 core test for the bindings exposure. cron 10 / discord 16 / core runtime_server 28 all green; typecheck + pnpm -r build green.

Unblocks claw morning summaries/reminders; this scheduler is also the testbed for durable timers (roadmap §2.3).