### PR TITLE
feat: claw Phase 0 — registry-dispatch skills skeleton

### DIFF
--- a/claw/.env.example
+++ b/claw/.env.example
@@ -22,3 +22,5 @@ CLAW_CODEX_CWD=
 CLAW_CODEX_TIMEOUT_MS=300000
 
 # CLAW_DB_PATH=
+# Separate SQLite file for the persistent skill registry (Phase 0).
+# CLAW_SKILL_DB_PATH=

--- a/claw/README.md
+++ b/claw/README.md
@@ -69,3 +69,55 @@ The bot uses these binding defaults:
 
 This is intentionally close to the Hermes-style scenario in
 `design-docs/runtime-bindings-discord-cron.md`.
+
+## Skills (Phase 0)
+
+Claw is being grown into a self-authoring meta-agent per
+`design-docs/claw-self-authoring.md`. **Phase 0** (this code) lands the
+registry-dispatch skeleton — no code-generation yet.
+
+A **skill** is a plain TypeScript value (`claw/src/skills/types.ts`):
+
+- `trigger` — `{ channel?, predicateKey, when(content, ctx) }`, the routing
+  predicate the dispatcher reads.
+- `behavior` — `(agent) => agent`, a subroutine body that produces the reply.
+- `provenance` — `{ authoredBy, motivation, createdAt }` for audit/pruning.
+
+### Registry-dispatch graph
+
+The main agent has one **static** shape, regardless of how many skills exist:
+
+```
+dispatch (transform)  → record the first matching skill id in a session var
+route (conditional)   → then: run that skill's behavior subroutine
+                        else: the default echo/openai/codex reply
+```
+
+Adding, enabling, or disabling a skill is a **registry row** change, never a
+graph recompile — so the parent graph's manifest hash is stable and long-lived
+conversations keep resuming (design §3/§8). A test asserts the parent manifest
+hash does not change when registry rows are added.
+
+### Persistence & health
+
+The `SkillRegistry` (`claw/src/skills/registry.ts`) is a separate SQLite store
+(its own file, default `.data/claw-skills.db`, override via
+`CLAW_SKILL_DB_PATH`). Rows carry the serializable subset (channel +
+`predicateKey` + `behaviorRef`); the executable `when`/`behavior` live in an
+in-process map keyed by skill id, joined at runtime. Unknown `behaviorRef`s warn
+at boot but never crash. Every skill invocation is instrumented into a per-skill
+health record (invocations, successes, consecutiveFailures, lastError,
+lastLatencyMs); no supervisor/tiers yet.
+
+### Seeded skill
+
+On first boot claw seeds one hand-written skill, `status`: a message beginning
+with `!status` (any channel) replies with the bot's version, reply mode, and
+uptime, e.g. `claw v0.0.1 | reply-mode: echo | uptime: 42s`.
+
+### Tests
+
+```bash
+pnpm -C claw test        # dispatch, persistence, health, disabled, manifest stability
+pnpm -C claw typecheck
+```

--- a/claw/package.json
+++ b/claw/package.json
@@ -7,17 +7,22 @@
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest --run --watch=false",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@prompttrail/core": "workspace:*",
     "@prompttrail/discord": "workspace:*",
     "@prompttrail/store-sqlite": "workspace:*",
+    "better-sqlite3": "^12.10.0",
     "dotenv": "^17.4.2"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.17.32",
     "tsx": "^4.19.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
   }
 }

--- a/claw/src/index.ts
+++ b/claw/src/index.ts
@@ -1,8 +1,16 @@
 import 'dotenv/config';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Agent, PromptTrail, Source } from '@prompttrail/core';
 import { discord, discordGateway } from '@prompttrail/discord';
 import { SqliteRunStore } from '@prompttrail/store-sqlite';
+import {
+  createClawSkillAgent,
+  createStatusSkill,
+  registerBuiltinSkills,
+  SkillRegistry,
+  validateSkillRegistry,
+} from './skills/index.js';
 
 interface ClawConfig {
   token: string;
@@ -19,47 +27,29 @@ interface ClawConfig {
 }
 
 const config = readConfig();
-
-let mainAgent: Agent;
-
-if (config.replyMode === 'echo') {
-  mainAgent = Agent.create('main').assistant(
-    'reply',
-    (session) => `ack: ${session.getLastMessage()?.content ?? ''}`,
-  );
-} else if (config.replyMode === 'openai') {
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error('CLAW_REPLY_MODE=openai requires OPENAI_API_KEY.');
-  }
-  if (!config.openaiModel) {
-    throw new Error('CLAW_REPLY_MODE=openai requires CLAW_OPENAI_MODEL.');
-  }
-  mainAgent = Agent.create('main')
-    .system(
-      'persona',
-      'You are Claw, a concise Discord-native PromptTrail agent.',
-    )
-    .assistant(
-      'reply',
-      Source.llm().openai({ adapter: 'ai-sdk', modelName: config.openaiModel }),
-    );
-} else {
-  // codex
-  mainAgent = Agent.create('main').codex('reply', {
-    transport: {
-      kind: 'websocket',
-      url: config.codexAppServerUrl,
-      timeoutMs: config.codexTimeoutMs,
-    },
-    cwd: config.codexCwd,
-    model: config.codexModel,
-    sandboxPolicy: { type: 'readOnly' },
-    approvalPolicy: 'never',
-  });
-}
+const startedAt = Date.now();
+const version = readPackageVersion();
 
 const clawDbPath =
   readOptionalString('CLAW_DB_PATH') ?? join(process.cwd(), '.data', 'claw.db');
+const skillDbPath =
+  readOptionalString('CLAW_SKILL_DB_PATH') ??
+  join(process.cwd(), '.data', 'claw-skills.db');
+
+// Persistent skill registry (design-docs/claw-self-authoring.md §7). Seeded
+// with the hand-written skills on first boot; unknown refs warn but never crash.
+const registry = new SkillRegistry(skillDbPath);
+const skills = registerBuiltinSkills(registry, [
+  createStatusSkill({ version, replyMode: config.replyMode, startedAt }),
+]);
+validateSkillRegistry(registry, skills);
+
+// Static registry-dispatch graph: dispatch → conditional(matched skill | default).
+const mainAgent = createClawSkillAgent({
+  registry,
+  skills,
+  defaultReply: buildDefaultReply(config),
+});
 
 const store = new SqliteRunStore({
   agents: { main: mainAgent },
@@ -111,12 +101,75 @@ const server = PromptTrail.server({
         console.log(`Claw Discord bot logged in as ${readyClient.user.tag}`);
         console.log(`Allowed channels: ${config.allowedChannels.join(', ')}`);
         console.log(`Reply mode: ${config.replyMode}`);
+        console.log(
+          `Skills: ${registry
+            .listEnabled()
+            .map((row) => row.id)
+            .join(', ')}`,
+        );
       },
     }),
   ],
 });
 
 await server.start();
+
+/**
+ * Build the default reply node(s) — the existing echo/openai/codex behavior,
+ * run when no skill trigger matches. Validation is fail-fast at boot.
+ */
+function buildDefaultReply(cfg: ClawConfig): (agent: Agent) => Agent {
+  if (cfg.replyMode === 'openai') {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('CLAW_REPLY_MODE=openai requires OPENAI_API_KEY.');
+    }
+    if (!cfg.openaiModel) {
+      throw new Error('CLAW_REPLY_MODE=openai requires CLAW_OPENAI_MODEL.');
+    }
+    const openaiModel = cfg.openaiModel;
+    return (agent) =>
+      agent
+        .system(
+          'persona',
+          'You are Claw, a concise Discord-native PromptTrail agent.',
+        )
+        .assistant(
+          'reply',
+          Source.llm().openai({ adapter: 'ai-sdk', modelName: openaiModel }),
+        );
+  }
+  if (cfg.replyMode === 'codex') {
+    return (agent) =>
+      agent.codex('reply', {
+        transport: {
+          kind: 'websocket',
+          url: cfg.codexAppServerUrl,
+          timeoutMs: cfg.codexTimeoutMs,
+        },
+        cwd: cfg.codexCwd,
+        model: cfg.codexModel,
+        sandboxPolicy: { type: 'readOnly' },
+        approvalPolicy: 'never',
+      });
+  }
+  // echo
+  return (agent) =>
+    agent.assistant(
+      'reply',
+      (session) => `ack: ${session.getLastMessage()?.content ?? ''}`,
+    );
+}
+
+function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
 
 function readConfig(): ClawConfig {
   const token = process.env.DISCORD_TOKEN;

--- a/claw/src/skills/dispatch.ts
+++ b/claw/src/skills/dispatch.ts
@@ -1,0 +1,171 @@
+import { Agent, type Session } from '@prompttrail/core';
+import { SkillRegistry } from './registry.js';
+import { MATCHED_SKILL_VAR, type Skill, type SkillContext } from './types.js';
+
+/**
+ * Registry-dispatch graph (design-docs/claw-self-authoring.md §3).
+ *
+ * The parent graph is STATIC:
+ *
+ *   dispatch (transform)  — reads the registry at runtime, records the first
+ *                           matching skill id in a session var
+ *   route (conditional)   — then: run the matched skill's behavior subroutine
+ *                           else: the existing default reply node
+ *
+ * Adding/removing/enabling a registry row never changes this shape, so the
+ * parent graph's manifest hash is stable and long-lived conversations keep
+ * resuming (the whole point of decision §3 / the §8 payoff).
+ */
+
+/** Read the dispatch-written matched skill id from an untyped session. */
+function readMatchedSkillId(session: Session): string {
+  const value = (session.getVarsObject() as Record<string, unknown>)[
+    MATCHED_SKILL_VAR
+  ];
+  return typeof value === 'string' ? value : '';
+}
+
+/** Build a {@link SkillContext} from the current session's last message. */
+export function toSkillContext(session: Session): SkillContext {
+  const last = session.getLastMessage();
+  const attrs = (last?.attrs ?? {}) as Record<string, unknown>;
+  return {
+    content: last?.content ?? '',
+    channel: typeof attrs.channel === 'string' ? attrs.channel : undefined,
+    channelId:
+      typeof attrs.channelId === 'string' ? attrs.channelId : undefined,
+    session,
+  };
+}
+
+function channelMatches(
+  configured: string | string[] | null | undefined,
+  ctx: SkillContext,
+): boolean {
+  if (configured === null || configured === undefined) {
+    return true;
+  }
+  const wanted = Array.isArray(configured) ? configured : [configured];
+  return wanted.some((c) => c === ctx.channel || c === ctx.channelId);
+}
+
+/**
+ * Joins persistent registry rows (order, enabled, channel) against the
+ * in-process skill map (the executable `when`/`behavior`). Returns the first
+ * enabled skill, in registry order, whose channel and predicate both match.
+ */
+export class SkillDispatcher {
+  constructor(
+    private readonly registry: SkillRegistry,
+    private readonly skills: Map<string, Skill>,
+  ) {}
+
+  match(ctx: SkillContext): Skill | undefined {
+    for (const row of this.registry.listEnabled()) {
+      const skill = this.skills.get(row.behaviorRef);
+      if (!skill) {
+        // Unknown ref: warned at boot (validateSkillRegistry); skip at runtime.
+        continue;
+      }
+      if (!channelMatches(row.channel, ctx)) {
+        continue;
+      }
+      if (skill.trigger.when(ctx.content, ctx)) {
+        return skill;
+      }
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Runs a skill's behavior subroutine and records the outcome to the registry
+ * health record (design-docs §9 Phase 0 slice). This explicit wrapper sits in
+ * the dispatch path so every skill invocation is instrumented: invocations,
+ * successes, consecutiveFailures, lastError, lastLatencyMs.
+ */
+export async function runSkillInstrumented(
+  registry: SkillRegistry,
+  skill: Skill,
+  session: Session,
+  now: () => number = Date.now,
+): Promise<Session> {
+  const start = now();
+  try {
+    const behaviorAgent = skill.behavior(
+      Agent.create(`skill-${skill.id.replace(/[^A-Za-z0-9_-]/g, '-')}`),
+    );
+    const result = (await behaviorAgent.execute({ session })) as Session;
+    registry.recordHealth(skill.id, {
+      success: true,
+      latencyMs: Math.max(0, now() - start),
+    });
+    return result;
+  } catch (error) {
+    registry.recordHealth(skill.id, {
+      success: false,
+      latencyMs: Math.max(0, now() - start),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+/** Warn (do not throw) on registry rows whose behaviorRef has no skill. */
+export function validateSkillRegistry(
+  registry: SkillRegistry,
+  skills: Map<string, Skill>,
+  warn: (message: string) => void = console.warn,
+): void {
+  for (const row of registry.list()) {
+    if (!skills.has(row.behaviorRef)) {
+      warn(
+        `Skill registry row "${row.id}" references unknown behavior "${row.behaviorRef}"; it will never match until the skill is loaded.`,
+      );
+    }
+  }
+}
+
+export interface ClawSkillAgentOptions {
+  registry: SkillRegistry;
+  /** Executable skills keyed by id (joined against registry rows). */
+  skills: Map<string, Skill>;
+  /** Builds the default reply node(s) — today's echo/openai/codex behavior. */
+  defaultReply: (agent: Agent) => Agent;
+  /** Injectable clock for deterministic health latencies in tests. */
+  now?: () => number;
+}
+
+/**
+ * Build claw's static registry-dispatch main agent. The graph shape is fixed
+ * regardless of how many skills are registered.
+ */
+export function createClawSkillAgent(options: ClawSkillAgentOptions): Agent {
+  const dispatcher = new SkillDispatcher(options.registry, options.skills);
+  const now = options.now ?? Date.now;
+
+  return Agent.create('main')
+    .transform('dispatch', (session) => {
+      const ctx = toSkillContext(session);
+      const matched = dispatcher.match(ctx);
+      return session.withVar(MATCHED_SKILL_VAR, matched?.id ?? '');
+    })
+    .conditional(
+      'route',
+      ({ session }) => readMatchedSkillId(session).length > 0,
+      (thenAgent) =>
+        thenAgent.transform(
+          'run-skill',
+          { effect: { repeatable: true } },
+          async (session) => {
+            const skillId = readMatchedSkillId(session);
+            const skill = options.skills.get(skillId);
+            if (!skill) {
+              return session;
+            }
+            return runSkillInstrumented(options.registry, skill, session, now);
+          },
+        ),
+      (elseAgent) => options.defaultReply(elseAgent),
+    );
+}

--- a/claw/src/skills/index.ts
+++ b/claw/src/skills/index.ts
@@ -1,0 +1,38 @@
+import type { SkillRegistry, SkillRegistryRow } from './registry.js';
+import type { Skill } from './types.js';
+
+export * from './types.js';
+export * from './registry.js';
+export * from './dispatch.js';
+export * from './status.js';
+
+/** Derive the serializable registry row from an in-process skill. */
+export function skillToRow(skill: Skill): SkillRegistryRow {
+  return {
+    id: skill.id,
+    name: skill.name,
+    channel: skill.trigger.channel ?? null,
+    predicateKey: skill.trigger.predicateKey,
+    behaviorRef: skill.id,
+    provenance: skill.provenance,
+    enabled: true,
+    createdAt: skill.provenance.createdAt,
+  };
+}
+
+/**
+ * Register built-in (hand-written) skills: build the in-process map and seed a
+ * registry row for each on first boot (idempotent — existing rows, including
+ * disabled ones, are left untouched).
+ */
+export function registerBuiltinSkills(
+  registry: SkillRegistry,
+  skills: readonly Skill[],
+): Map<string, Skill> {
+  const map = new Map<string, Skill>();
+  for (const skill of skills) {
+    map.set(skill.id, skill);
+    registry.seedIfMissing(skillToRow(skill));
+  }
+  return map;
+}

--- a/claw/src/skills/registry.ts
+++ b/claw/src/skills/registry.ts
@@ -1,0 +1,258 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import Database from 'better-sqlite3';
+import type { SkillProvenance } from './types.js';
+
+/**
+ * Persistent SkillRegistry (design-docs/claw-self-authoring.md §7).
+ *
+ * A deliberately separate abstraction from the run store: its access pattern is
+ * load-all-on-boot plus occasional append/enable/disable and per-invocation
+ * health writes, not per-run checkpoint deltas. Backed by its own SQLite file
+ * via better-sqlite3.
+ *
+ * Phase 0 rows carry only the *serializable* subset of a skill: the executable
+ * `when`/`behavior` live in the in-process skill map (keyed by `behaviorRef`),
+ * which the dispatcher joins against at runtime. `channel` + `predicateKey`
+ * describe the trigger; `behaviorRef` is the in-process skill id.
+ */
+
+/** A persisted skill row (the serializable subset of a {@link Skill}). */
+export interface SkillRegistryRow {
+  id: string;
+  name: string;
+  /** Serializable trigger channel narrowing; null means "any channel". */
+  channel: string | string[] | null;
+  /** Serializable name of the trigger predicate (Phase 0: informational). */
+  predicateKey: string;
+  /** Reference to the executable skill in the in-process map (Phase 0: id). */
+  behaviorRef: string;
+  provenance: SkillProvenance;
+  enabled: boolean;
+  createdAt: string;
+}
+
+/** Per-skill health record (design-docs/claw-self-authoring.md §9 Phase 0). */
+export interface SkillHealthRecord {
+  skillId: string;
+  invocations: number;
+  successes: number;
+  consecutiveFailures: number;
+  lastError: string | null;
+  lastLatencyMs: number | null;
+  updatedAt: string;
+}
+
+/** Outcome recorded for one skill invocation. */
+export interface SkillHealthUpdate {
+  success: boolean;
+  latencyMs: number;
+  error?: string;
+}
+
+interface SkillRow {
+  id: string;
+  name: string;
+  channel: string | null;
+  predicate_key: string;
+  behavior_ref: string;
+  provenance: string;
+  enabled: number;
+  created_at: string;
+}
+
+interface HealthRow {
+  skill_id: string;
+  invocations: number;
+  successes: number;
+  consecutive_failures: number;
+  last_error: string | null;
+  last_latency_ms: number | null;
+  updated_at: string;
+}
+
+export class SkillRegistry {
+  private readonly db: Database.Database;
+
+  constructor(path: string) {
+    if (path !== ':memory:') {
+      mkdirSync(dirname(path), { recursive: true });
+    }
+    this.db = new Database(path);
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS skills (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        channel TEXT,
+        predicate_key TEXT NOT NULL,
+        behavior_ref TEXT NOT NULL,
+        provenance TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS skill_health (
+        skill_id TEXT PRIMARY KEY,
+        invocations INTEGER NOT NULL DEFAULT 0,
+        successes INTEGER NOT NULL DEFAULT 0,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        last_latency_ms INTEGER,
+        updated_at TEXT NOT NULL
+      );
+    `);
+  }
+
+  /** All rows in insertion order, enabled or not. */
+  list(): SkillRegistryRow[] {
+    const rows = this.db
+      .prepare('SELECT * FROM skills ORDER BY rowid')
+      .all() as SkillRow[];
+    return rows.map(fromSkillRow);
+  }
+
+  /** Enabled rows only, in insertion (dispatch-priority) order. */
+  listEnabled(): SkillRegistryRow[] {
+    const rows = this.db
+      .prepare('SELECT * FROM skills WHERE enabled = 1 ORDER BY rowid')
+      .all() as SkillRow[];
+    return rows.map(fromSkillRow);
+  }
+
+  get(id: string): SkillRegistryRow | undefined {
+    const row = this.db.prepare('SELECT * FROM skills WHERE id = ?').get(id) as
+      | SkillRow
+      | undefined;
+    return row ? fromSkillRow(row) : undefined;
+  }
+
+  /** Insert a row, replacing any existing row with the same id. */
+  upsert(row: SkillRegistryRow): void {
+    this.db
+      .prepare(
+        `INSERT INTO skills
+           (id, name, channel, predicate_key, behavior_ref, provenance, enabled, created_at)
+         VALUES (@id, @name, @channel, @predicate_key, @behavior_ref, @provenance, @enabled, @created_at)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           channel = excluded.channel,
+           predicate_key = excluded.predicate_key,
+           behavior_ref = excluded.behavior_ref,
+           provenance = excluded.provenance,
+           enabled = excluded.enabled`,
+      )
+      .run(toSkillRow(row));
+  }
+
+  /** Seed a row only if no row with that id exists yet (first-boot seeding). */
+  seedIfMissing(row: SkillRegistryRow): boolean {
+    const result = this.db
+      .prepare(
+        `INSERT OR IGNORE INTO skills
+           (id, name, channel, predicate_key, behavior_ref, provenance, enabled, created_at)
+         VALUES (@id, @name, @channel, @predicate_key, @behavior_ref, @provenance, @enabled, @created_at)`,
+      )
+      .run(toSkillRow(row));
+    return result.changes > 0;
+  }
+
+  /** Enable/disable a skill by row update (revocation is `false`). */
+  setEnabled(id: string, enabled: boolean): void {
+    this.db
+      .prepare('UPDATE skills SET enabled = ? WHERE id = ?')
+      .run(enabled ? 1 : 0, id);
+  }
+
+  /** Record one skill invocation outcome into its health record. */
+  recordHealth(skillId: string, update: SkillHealthUpdate): SkillHealthRecord {
+    const now = new Date().toISOString();
+    const current = this.getHealth(skillId);
+    const next: SkillHealthRecord = {
+      skillId,
+      invocations: (current?.invocations ?? 0) + 1,
+      successes: (current?.successes ?? 0) + (update.success ? 1 : 0),
+      consecutiveFailures: update.success
+        ? 0
+        : (current?.consecutiveFailures ?? 0) + 1,
+      lastError: update.success
+        ? (current?.lastError ?? null)
+        : (update.error ?? null),
+      lastLatencyMs: update.latencyMs,
+      updatedAt: now,
+    };
+    this.db
+      .prepare(
+        `INSERT INTO skill_health
+           (skill_id, invocations, successes, consecutive_failures, last_error, last_latency_ms, updated_at)
+         VALUES (@skill_id, @invocations, @successes, @consecutive_failures, @last_error, @last_latency_ms, @updated_at)
+         ON CONFLICT(skill_id) DO UPDATE SET
+           invocations = excluded.invocations,
+           successes = excluded.successes,
+           consecutive_failures = excluded.consecutive_failures,
+           last_error = excluded.last_error,
+           last_latency_ms = excluded.last_latency_ms,
+           updated_at = excluded.updated_at`,
+      )
+      .run({
+        skill_id: next.skillId,
+        invocations: next.invocations,
+        successes: next.successes,
+        consecutive_failures: next.consecutiveFailures,
+        last_error: next.lastError,
+        last_latency_ms: next.lastLatencyMs,
+        updated_at: next.updatedAt,
+      });
+    return next;
+  }
+
+  getHealth(skillId: string): SkillHealthRecord | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM skill_health WHERE skill_id = ?')
+      .get(skillId) as HealthRow | undefined;
+    if (!row) {
+      return undefined;
+    }
+    return {
+      skillId: row.skill_id,
+      invocations: row.invocations,
+      successes: row.successes,
+      consecutiveFailures: row.consecutive_failures,
+      lastError: row.last_error,
+      lastLatencyMs: row.last_latency_ms,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+function fromSkillRow(row: SkillRow): SkillRegistryRow {
+  return {
+    id: row.id,
+    name: row.name,
+    channel:
+      row.channel === null
+        ? null
+        : (JSON.parse(row.channel) as string | string[]),
+    predicateKey: row.predicate_key,
+    behaviorRef: row.behavior_ref,
+    provenance: JSON.parse(row.provenance) as SkillProvenance,
+    enabled: row.enabled === 1,
+    createdAt: row.created_at,
+  };
+}
+
+function toSkillRow(row: SkillRegistryRow): SkillRow {
+  return {
+    id: row.id,
+    name: row.name,
+    channel: row.channel === null ? null : JSON.stringify(row.channel),
+    predicate_key: row.predicateKey,
+    behavior_ref: row.behaviorRef,
+    provenance: JSON.stringify(row.provenance),
+    enabled: row.enabled ? 1 : 0,
+    created_at: row.createdAt,
+  };
+}

--- a/claw/src/skills/skills.test.ts
+++ b/claw/src/skills/skills.test.ts
@@ -1,0 +1,297 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  Agent,
+  createAgentGraphManifest,
+  Session,
+  Source,
+} from '@prompttrail/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createClawSkillAgent,
+  createStatusSkill,
+  registerBuiltinSkills,
+  runSkillInstrumented,
+  SkillRegistry,
+  skillToRow,
+  statusMessage,
+  type Skill,
+} from './index.js';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'claw-skills-'));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function dbPath(name = 'skills.db'): string {
+  return join(tmp, name);
+}
+
+/** A default reply builder that echoes the last message (the else branch). */
+const echoDefault = (agent: Agent): Agent =>
+  agent.assistant(
+    'reply',
+    (session: Session) => `ack: ${session.getLastMessage()?.content ?? ''}`,
+  );
+
+function userSession(content: string, channel?: string): Session {
+  return Session.create().addMessage({
+    type: 'user',
+    content,
+    attrs: channel ? { channel } : undefined,
+  });
+}
+
+function lastContent(session: Session): string {
+  return session.getLastMessage()?.content ?? '';
+}
+
+describe('status skill', () => {
+  it('formats version, reply mode, and uptime deterministically', () => {
+    const message = statusMessage({
+      version: '1.2.3',
+      replyMode: 'echo',
+      startedAt: 1000,
+      now: () => 61000,
+    });
+    expect(message).toBe('claw v1.2.3 | reply-mode: echo | uptime: 60s');
+  });
+});
+
+describe('dispatch', () => {
+  it('runs the matched skill behavior and echoes otherwise', async () => {
+    const registry = new SkillRegistry(dbPath());
+    const skills = registerBuiltinSkills(registry, [
+      createStatusSkill({
+        version: '9.9.9',
+        replyMode: 'echo',
+        startedAt: 0,
+        now: () => 5000,
+      }),
+    ]);
+    const agent = createClawSkillAgent({
+      registry,
+      skills,
+      defaultReply: echoDefault,
+    });
+
+    const matched = await agent.execute({ session: userSession('!status') });
+    expect(lastContent(matched)).toBe(
+      'claw v9.9.9 | reply-mode: echo | uptime: 5s',
+    );
+
+    const unmatched = await agent.execute({ session: userSession('hello') });
+    expect(lastContent(unmatched)).toBe('ack: hello');
+
+    registry.close();
+  });
+
+  it('honors trigger.channel narrowing', async () => {
+    const registry = new SkillRegistry(dbPath());
+    const skill: Skill = {
+      id: 'greet',
+      name: 'Greet',
+      trigger: {
+        channel: 'welcome',
+        predicateKey: 'startsWith:hi',
+        when: (content) => content.startsWith('hi'),
+      },
+      behavior: (agent) => agent.assistant(Source.literal('hello there')),
+      provenance: {
+        authoredBy: 'test',
+        motivation: 'channel narrowing',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const skills = registerBuiltinSkills(registry, [skill]);
+    const agent = createClawSkillAgent({
+      registry,
+      skills,
+      defaultReply: echoDefault,
+    });
+
+    const inChannel = await agent.execute({
+      session: userSession('hi', 'welcome'),
+    });
+    expect(lastContent(inChannel)).toBe('hello there');
+
+    const wrongChannel = await agent.execute({
+      session: userSession('hi', 'random'),
+    });
+    expect(lastContent(wrongChannel)).toBe('ack: hi');
+
+    registry.close();
+  });
+});
+
+describe('registry persistence', () => {
+  it('rows survive a simulated restart (new instance, same file)', () => {
+    const path = dbPath('persist.db');
+    const first = new SkillRegistry(path);
+    const seeded = first.seedIfMissing(
+      skillToRow(
+        createStatusSkill({
+          version: '1.0.0',
+          replyMode: 'echo',
+          startedAt: 0,
+        }),
+      ),
+    );
+    expect(seeded).toBe(true);
+    first.close();
+
+    const restarted = new SkillRegistry(path);
+    const rows = restarted.list();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'status',
+      name: 'Status',
+      behaviorRef: 'status',
+      enabled: true,
+    });
+    // Seeding again is idempotent — no duplicate row.
+    expect(restarted.seedIfMissing(skillToRow(statusSkill()))).toBe(false);
+    expect(restarted.list()).toHaveLength(1);
+    restarted.close();
+  });
+});
+
+function statusSkill(): Skill {
+  return createStatusSkill({
+    version: '1.0.0',
+    replyMode: 'echo',
+    startedAt: 0,
+  });
+}
+
+describe('health record', () => {
+  it('increments invocations/successes on success', async () => {
+    const registry = new SkillRegistry(dbPath());
+    const skills = registerBuiltinSkills(registry, [statusSkill()]);
+    const skill = skills.get('status')!;
+
+    let clock = 0;
+    await runSkillInstrumented(registry, skill, userSession('!status'), () => {
+      clock += 10;
+      return clock;
+    });
+
+    const health = registry.getHealth('status');
+    expect(health).toMatchObject({
+      skillId: 'status',
+      invocations: 1,
+      successes: 1,
+      consecutiveFailures: 0,
+      lastError: null,
+    });
+    expect(health?.lastLatencyMs).toBe(10);
+    registry.close();
+  });
+
+  it('increments consecutiveFailures and records lastError on failure', async () => {
+    const registry = new SkillRegistry(dbPath());
+    const boom: Skill = {
+      id: 'boom',
+      name: 'Boom',
+      trigger: {
+        predicateKey: 'always',
+        when: () => true,
+      },
+      behavior: (agent) =>
+        agent.assistant(
+          Source.callback(async () => {
+            throw new Error('kaboom');
+          }),
+        ),
+      provenance: {
+        authoredBy: 'test',
+        motivation: 'failure path',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    registerBuiltinSkills(registry, [boom]);
+
+    await expect(
+      runSkillInstrumented(registry, boom, userSession('go')),
+    ).rejects.toThrow('kaboom');
+    await expect(
+      runSkillInstrumented(registry, boom, userSession('go')),
+    ).rejects.toThrow('kaboom');
+
+    const health = registry.getHealth('boom');
+    expect(health).toMatchObject({
+      invocations: 2,
+      successes: 0,
+      consecutiveFailures: 2,
+      lastError: 'kaboom',
+    });
+    registry.close();
+  });
+});
+
+describe('disabled skills', () => {
+  it('are skipped by the dispatcher', async () => {
+    const registry = new SkillRegistry(dbPath());
+    const skills = registerBuiltinSkills(registry, [
+      createStatusSkill({ version: '1.0.0', replyMode: 'echo', startedAt: 0 }),
+    ]);
+    registry.setEnabled('status', false);
+
+    const agent = createClawSkillAgent({
+      registry,
+      skills,
+      defaultReply: echoDefault,
+    });
+    const result = await agent.execute({ session: userSession('!status') });
+    expect(lastContent(result)).toBe('ack: !status');
+    registry.close();
+  });
+});
+
+describe('parent graph stability', () => {
+  it('manifest hash is unchanged when a registry row is added', () => {
+    const registry = new SkillRegistry(dbPath());
+    const skills = new Map<string, Skill>();
+    const build = () =>
+      createClawSkillAgent({ registry, skills, defaultReply: echoDefault });
+
+    const before = createAgentGraphManifest(build().toGraph()).hash;
+
+    // Adding a skill row must NOT change the parent graph structure/hash.
+    const status = createStatusSkill({
+      version: '1.0.0',
+      replyMode: 'echo',
+      startedAt: 0,
+    });
+    skills.set(status.id, status);
+    registry.seedIfMissing(skillToRow(status));
+
+    const afterOne = createAgentGraphManifest(build().toGraph()).hash;
+
+    const extra: Skill = {
+      id: 'extra',
+      name: 'Extra',
+      trigger: { predicateKey: 'never', when: () => false },
+      behavior: (agent) => agent.assistant(Source.literal('x')),
+      provenance: {
+        authoredBy: 'test',
+        motivation: 'second row',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    skills.set(extra.id, extra);
+    registry.seedIfMissing(skillToRow(extra));
+
+    const afterTwo = createAgentGraphManifest(build().toGraph()).hash;
+
+    expect(afterOne).toBe(before);
+    expect(afterTwo).toBe(before);
+    registry.close();
+  });
+});

--- a/claw/src/skills/status.ts
+++ b/claw/src/skills/status.ts
@@ -1,0 +1,48 @@
+import { Source } from '@prompttrail/core';
+import type { Skill } from './types.js';
+
+/** Runtime facts the status skill reports back to the channel. */
+export interface StatusInfo {
+  version: string;
+  replyMode: string;
+  /** Process/boot start time (ms epoch) used to compute uptime. */
+  startedAt: number;
+  /** Injectable clock for deterministic tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+/** The `!status` trigger prefix (case-insensitive, leading whitespace ok). */
+const STATUS_PREFIX = '!status';
+
+export function statusMessage(info: StatusInfo): string {
+  const now = (info.now ?? Date.now)();
+  const uptimeSec = Math.max(0, Math.floor((now - info.startedAt) / 1000));
+  return `claw v${info.version} | reply-mode: ${info.replyMode} | uptime: ${uptimeSec}s`;
+}
+
+/**
+ * Hand-written Phase 0 skill (design-docs/claw-self-authoring.md §10).
+ *
+ * Trigger: a message beginning with `!status` (any channel). Behavior: reply
+ * with the bot's version, active reply mode, and uptime. Deterministic (given
+ * an injected clock) so the dispatch path is testable without an LLM.
+ */
+export function createStatusSkill(info: StatusInfo): Skill {
+  return {
+    id: 'status',
+    name: 'Status',
+    trigger: {
+      predicateKey: 'startsWith:!status',
+      when: (content) =>
+        content.trimStart().toLowerCase().startsWith(STATUS_PREFIX),
+    },
+    behavior: (agent) =>
+      agent.assistant(Source.callback(async () => statusMessage(info))),
+    provenance: {
+      authoredBy: 'claw-maintainers',
+      motivation:
+        'Hand-written Phase 0 skill: report bot version, reply mode, and uptime on "!status".',
+      createdAt: '2026-07-08T00:00:00.000Z',
+    },
+  };
+}

--- a/claw/src/skills/types.ts
+++ b/claw/src/skills/types.ts
@@ -1,0 +1,62 @@
+import type { Agent, Session } from '@prompttrail/core';
+
+/**
+ * Phase 0 skill model (design-docs/claw-self-authoring.md §2).
+ *
+ * A skill is a plain TypeScript value with three parts:
+ *   - `trigger`  — a routing predicate (channel + `when`) the dispatcher reads.
+ *   - `behavior` — a subroutine body: `(agent) => agent`, the reply logic.
+ *   - `provenance` — who authored it and why, for audit/pruning.
+ *
+ * Types are intentionally local to claw for Phase 0; core stays untouched.
+ */
+
+/** Runtime context handed to a trigger predicate when routing a message. */
+export interface SkillContext {
+  /** Human-readable channel name of the inbound message, if known. */
+  channel?: string;
+  /** Stable channel id of the inbound message, if known. */
+  channelId?: string;
+  /** The inbound message content the predicate matches against. */
+  content: string;
+  /** The full session at dispatch time (read-only use in predicates). */
+  session: Session;
+}
+
+/**
+ * A skill's routing predicate.
+ *
+ * `predicateKey` is the *serializable* name of `when` — it is what a registry
+ * row persists (Phase 0 has no code-gen, so the executable `when` always comes
+ * from the in-process skill map, keyed by skill id). `channel` narrows which
+ * channel(s) the skill applies to; `undefined` matches any channel.
+ */
+export interface SkillTrigger {
+  channel?: string | string[];
+  /** Named, serializable identity of the predicate (persisted on the row). */
+  predicateKey: string;
+  when: (content: string, ctx: SkillContext) => boolean;
+}
+
+/** Audit trail: who authored a skill, the motivating instruction, and when. */
+export interface SkillProvenance {
+  authoredBy: string;
+  motivation: string;
+  /** ISO-8601 timestamp of authoring (not of any single invocation). */
+  createdAt: string;
+}
+
+/**
+ * The unit of self-authored behavior. `behavior` is a subroutine body builder:
+ * given a fresh `Agent`, it appends the reply logic and returns the agent.
+ */
+export interface Skill {
+  id: string;
+  name: string;
+  trigger: SkillTrigger;
+  behavior: (agent: Agent) => Agent;
+  provenance: SkillProvenance;
+}
+
+/** Session var the dispatch transform writes the matched skill id into. */
+export const MATCHED_SKILL_VAR = '__claw_matched_skill';

--- a/claw/vitest.config.ts
+++ b/claw/vitest.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@prompttrail/core/runtime_server',
+        replacement: new URL(
+          '../packages/core/src/runtime_server.ts',
+          import.meta.url,
+        ).pathname,
+      },
+      {
+        find: '@prompttrail/core/runtime_dispatch',
+        replacement: new URL(
+          '../packages/core/src/runtime_dispatch.ts',
+          import.meta.url,
+        ).pathname,
+      },
+      {
+        find: '@prompttrail/core',
+        replacement: new URL('../packages/core/src/index.ts', import.meta.url)
+          .pathname,
+      },
+    ],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,10 +111,16 @@ importers:
       '@prompttrail/store-sqlite':
         specifier: workspace:*
         version: link:../packages/store-sqlite
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^20.17.32
         version: 20.17.32
@@ -124,6 +130,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.17.32)(lightningcss@1.29.2)
 
   examples:
     dependencies:
@@ -2973,7 +2982,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
Implements Phase 0 of design-docs/claw-self-authoring.md (registry-dispatch, no code-gen):

- Static parent graph: inbox → dispatch transform → conditional → matched skill subroutine | default reply (echo/openai/codex modes unchanged as the default)
- Skills are typed TS values (trigger + behavior + provenance) looked up from a persistent SkillRegistry (own sqlite file; distinct access pattern from the run store per §7)
- Seeded hand-written 'status' skill; enable/disable = row update; unknown refs warn at boot
- §9 Phase-0 slice: per-skill health records persisted on every invocation
- Key architectural guarantee under test: adding registry rows does NOT change the parent graph manifest hash — long-lived conversations keep resuming as skills evolve

claw: typecheck green, 8 new tests. core 733 / discord 16 / cron 10 green; pnpm -r build green.

Known Phase-0 relaxation (documented in code): the dispatch transform reads the registry (hidden effect) — a mid-run enable/disable could re-match differently under replay; revisit with the Phase 1 gate.