### PR TITLE
fix: crash-window input loss — cursor persists only with terminal-boundary state

### DIFF
--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -953,6 +953,135 @@ describe('checkpoint app runtime', () => {
     ]);
   });
 
+  it('does not lose inbox input when the process crashes mid-execution', async () => {
+    // Model a HARD process crash mid-execution (bypassing the error handler):
+    // capture a deep copy of the durably persisted run state at the first
+    // mid-execution persist, then rehydrate a FRESH app instance from that
+    // snapshot. Under the old optimistic advance the persisted cursor had
+    // already jumped to inbox.length before the graph ran, so a crash here
+    // dropped 'hello' forever.
+    const runId = 'run-crash';
+    const buildAgent = () =>
+      Agent.create('crash')
+        .inbox('in')
+        .assistant('reply', Source.literal('ok'));
+
+    let snapshot: StoredRun<any> | undefined;
+    class CrashSnapshotStore extends MemoryRunStore {
+      async patch(
+        rid: string,
+        patch: StoredRunPatch,
+        fence?: number,
+      ): Promise<void> {
+        await super.patch(rid, patch, fence);
+        // First patch during execution (run.started observer): the executor is
+        // running but no boundary has been reached.
+        if (snapshot) {
+          return;
+        }
+        const live = (await this.get(rid))!;
+        if (live.status !== 'open') {
+          return;
+        }
+        snapshot = {
+          agent: buildAgent(),
+          agentName: live.agentName,
+          graphManifest: live.graphManifest,
+          initial: live.initial,
+          status: live.status,
+          result: live.result,
+          once: {
+            run: new Map(live.once.run),
+            conversation: new Map(live.once.conversation),
+          },
+          outbox: [...live.outbox],
+          inbox: live.inbox.map((entry) => ({ ...entry })),
+          providerSessions: { ...(live.providerSessions ?? {}) },
+          graphCursor: live.graphCursor,
+          graphSuspendedAt: live.graphSuspendedAt,
+          context: live.context,
+        };
+      }
+    }
+
+    const storeA = new CrashSnapshotStore();
+    const appA = PromptTrail.app({
+      agents: { crash: buildAgent() },
+      store: storeA,
+    });
+    await appA.run({ agent: 'crash', runId, input: 'hello', checkpoint: true });
+
+    // The durable state captured at the crash point must NOT have advanced the
+    // inbox cursor ahead of the (still-empty) session checkpoint.
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.graphCursor ?? 0).toBe(0);
+    expect(snapshot?.result?.messages ?? []).toEqual([]);
+
+    // Rehydrate a fresh app from the crash snapshot and resume: the unconsumed
+    // input is re-delivered and processed, not lost.
+    const storeB = new MemoryRunStore();
+    await storeB.create(runId, snapshot!);
+    const appB = PromptTrail.app({
+      agents: { crash: buildAgent() },
+      store: storeB,
+    });
+    const recovered = await appB.resume(runId);
+    expect(recovered.status).toBe('done');
+    expect(
+      recovered.session.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ok']);
+  });
+
+  it('advances the persisted cursor to the consumed count at a suspension boundary', async () => {
+    const store = memoryStore();
+    const assistant = Agent.create('suspend-cursor')
+      .inbox('first')
+      .assistant('ack', Source.literal('ack'))
+      .awaitInput('more');
+    const app = PromptTrail.app({ agents: { s: assistant }, store });
+
+    const suspended = await app.run({
+      agent: 's',
+      runId: 'run-suspend-cursor',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(suspended.status).toBe('suspended');
+
+    // One inbox message was consumed before suspending; the persisted cursor and
+    // session agree on exactly that count.
+    const persisted = await store.get('run-suspend-cursor');
+    expect(persisted?.graphCursor).toBe(1);
+    expect(
+      persisted?.result?.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ack']);
+  });
+
+  it('advances the persisted cursor to the consumed count at a completion boundary', async () => {
+    const store = memoryStore();
+    // A graph without an inbound consumer materializes the whole inbox remainder
+    // at completion, so the persisted cursor covers every delivered message.
+    const assistant = Agent.create('complete-cursor').assistant(
+      'reply',
+      Source.literal('ok'),
+    );
+    const app = PromptTrail.app({ agents: { c: assistant }, store });
+
+    const done = await app.run({
+      agent: 'c',
+      runId: 'run-complete-cursor',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(done.status).toBe('done');
+
+    const persisted = await store.get('run-complete-cursor');
+    expect(persisted?.graphCursor).toBe(1);
+    expect(
+      persisted?.result?.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ok']);
+  });
+
   it('delete removes the run from the store and prunes the process-local maps', async () => {
     const store = memoryStore();
     const assistant = Agent.create('deletable')
@@ -1076,18 +1205,23 @@ describe('checkpoint app runtime', () => {
   });
 
   it('surfaces both the run error and the rollback error when rollback persistence fails', async () => {
+    // The inbox cursor is never advanced before a graph boundary, so every
+    // mid-attempt persist writes the same (entry) cursor and the rollback
+    // persist is indistinguishable from the others by content — only by order.
+    // The failing transform arms the store to fail the persist that follows the
+    // single `run.failed` observer persist, i.e. the rollback persist itself.
     class RollbackFailStore extends MemoryRunStore {
-      private advanced = false;
+      // null: disarmed; n>0: let n more patches through, then fail the next.
+      patchesUntilFailure: number | null = null;
       async patch(
         runId: string,
         patch: Parameters<MemoryRunStore['patch']>[1],
       ): Promise<void> {
-        if (patch.graphCursor === 1) {
-          this.advanced = true;
-        }
-        // Fail only the rewind write (cursor regressing to 0 after advancing).
-        if (this.advanced && patch.graphCursor === 0) {
-          throw new Error('store patch failed');
+        if (this.patchesUntilFailure !== null) {
+          if (this.patchesUntilFailure === 0) {
+            throw new Error('store patch failed');
+          }
+          this.patchesUntilFailure -= 1;
         }
         return super.patch(runId, patch);
       }
@@ -1098,6 +1232,10 @@ describe('checkpoint app runtime', () => {
       .inbox('in')
       .assistant('reply', Source.literal('ok'))
       .transform('boom', () => {
+        // Arm the store so the run.failed observer persist still succeeds and
+        // the subsequent rollback persist (restoreCheckpointGraphEntryPoint)
+        // fails.
+        store.patchesUntilFailure = 1;
         throw new Error('boom');
       });
     const app = PromptTrail.app({ agents: { rollback: assistant }, store });

--- a/packages/core/src/checkpoint_continuation.ts
+++ b/packages/core/src/checkpoint_continuation.ts
@@ -54,11 +54,25 @@ export interface CheckpointGraphExecutionStart<TVars extends Vars, TInbound> {
  *
  * The run store keeps the latest session checkpoint and inbox cursor at graph
  * boundaries. A resume never replays an old journal; it starts from the stored
- * session, advances the inbox cursor optimistically to the current end, and runs
- * the graph forward. For continuations, deterministic bootstrap nodes before the
- * next inbound/suspended coordinate are skipped once so static system/user
+ * session and the stored inbox cursor and runs the graph forward over the
+ * unconsumed inbox tail. For continuations, deterministic bootstrap nodes before
+ * the next inbound/suspended coordinate are skipped once so static system/user
  * prefixes are not duplicated, while `resumeFromNode` lets loops re-enter the
  * suspended node's children even when their condition is currently false.
+ *
+ * Persistence contract (crash-durability): the inbox cursor is NEVER advanced
+ * before the graph runs. It advances only at a terminal boundary — suspension
+ * ({@link recordCheckpointGraphSuspension}) or completion
+ * ({@link recordCheckpointGraphCompletion}) — in the SAME persist that writes the
+ * session the graph produced, and to a value derived from how much inbox the
+ * executor actually consumed. Because that single persist writes the session
+ * delta before the cursor, at every rest point (including a hard process crash
+ * mid-execution, which the error handler cannot intercept) the persisted
+ * `(graphCursor, session)` pair is mutually consistent and the cursor is never
+ * ahead of the consumption the persisted session reflects. A cold restart after
+ * a mid-execution crash therefore re-delivers the still-unconsumed inbox tail
+ * (at-least-once); keyed effects dedupe via the once memo / declared idempotency
+ * keys so re-running the interrupted attempt is safe.
  *
  * Keyed external effects are still at-least-once. The local once memo records
  * keyed durable effect results after the effect and before the next checkpoint
@@ -66,35 +80,27 @@ export interface CheckpointGraphExecutionStart<TVars extends Vars, TInbound> {
  * still requires the remote system to deduplicate by the declared idempotency
  * key. Repeatable effects deliberately bypass this memo.
  *
- * Error rollback invariant: the persisted `(graphCursor, session)` pair MUST
- * stay mutually consistent at rest — both must agree on how much of the inbox
- * has been consumed. The cursor is advanced optimistically before the graph
- * runs, so a non-suspend error must discard the whole attempt via
- * {@link restoreCheckpointGraphEntryPoint}, resetting the cursor, the session,
- * and the suspension coordinate to the entry point captured here. Otherwise a
- * retry would replay already-consumed inbox messages against an advanced
- * session and duplicate them. A suspension is NOT a failure and never rolls
- * back. If the rollback persist itself fails, both the original run error and
- * the rollback error are surfaced together via {@link CheckpointRollbackError}.
+ * Error rollback: a non-suspend error discards the attempt via
+ * {@link restoreCheckpointGraphEntryPoint}, re-asserting the entry-point cursor,
+ * session, and suspension coordinate captured here. Because none of those fields
+ * are advanced before a boundary, the reset is a no-op in the common case, but
+ * the explicit re-assert keeps the persisted `(graphCursor, session)` pair
+ * consistent even if a future change mutates them mid-attempt. A suspension is
+ * NOT a failure and never rolls back. If the rollback persist itself fails, both
+ * the original run error and the rollback error are surfaced together via
+ * {@link CheckpointRollbackError}.
  */
-export async function beginCheckpointGraphExecution<
-  TVars extends Vars,
-  TInbound,
->(
+export function beginCheckpointGraphExecution<TVars extends Vars, TInbound>(
   run: CheckpointGraphRunState<TVars, TInbound>,
-  persist: () => Promise<void>,
-): Promise<CheckpointGraphExecutionStart<TVars, TInbound>> {
+): CheckpointGraphExecutionStart<TVars, TInbound> {
   const cursor = run.graphCursor ?? 0;
-  const start: CheckpointGraphExecutionStart<TVars, TInbound> = {
+  return {
     cursor,
     session: run.result ?? run.initial,
     inbox: run.inbox.slice(cursor),
     resumeFromNode: deriveCheckpointResumeCoordinate(run),
     isContinuation: run.result !== undefined,
   };
-  run.graphCursor = run.inbox.length;
-  await persist();
-  return start;
 }
 
 /**
@@ -175,10 +181,12 @@ export async function recordCheckpointGraphCompletion<
 >(
   run: CompletableCheckpointGraphRunState<TVars, TInbound>,
   session: Session<TVars>,
+  graphCursor: number,
   persist: () => Promise<void>,
 ): Promise<void> {
   run.status = 'done';
   run.result = session;
+  run.graphCursor = graphCursor;
   run.graphSuspendedAt = undefined;
   await persist();
 }
@@ -190,9 +198,11 @@ export async function recordCheckpointGraphSuspension<
   run: CheckpointGraphRunState<TVars, TInbound>,
   nodePath: string,
   session: Session<TVars>,
+  graphCursor: number,
   persist: () => Promise<void>,
 ): Promise<void> {
   run.result = session;
+  run.graphCursor = graphCursor;
   run.graphSuspendedAt = nodePath;
   await persist();
 }

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -1419,9 +1419,13 @@ export class PromptTrailApp {
     run: StoredRun<TVars> & { agent: Agent<TVars> },
   ): Promise<DurableRunResult<TVars>> {
     const graph = run.agent.toGraph();
-    const checkpoint = await beginCheckpointGraphExecution(run, () =>
-      this.persistRun(runId, run),
-    );
+    const checkpoint = beginCheckpointGraphExecution(run);
+    // The persisted inbox cursor must never run ahead of the session the graph
+    // has actually produced, so it is advanced only at a terminal boundary
+    // (completion/suspension) to a value derived from how much of the inbox the
+    // executor consumed. `consumedInSlice` tracks that count for the tail slice
+    // handed to this attempt; the absolute cursor is `checkpoint.cursor + it`.
+    let consumedInSlice = 0;
     const skipNodePaths = checkpoint.isContinuation
       ? computeCheckpointContinuationSkipNodes(
           graph.nodes,
@@ -1466,6 +1470,9 @@ export class PromptTrailApp {
           strictObservers: this.strictObservers,
           resumeFromNode: checkpoint.resumeFromNode,
           skipNode: createCheckpointContinuationSkipPredicate(skipNodePaths),
+          onInboxConsumed: (consumed) => {
+            consumedInSlice = consumed;
+          },
           observers: [
             async (event) => {
               await this.emitObservers(run, event);
@@ -1474,10 +1481,15 @@ export class PromptTrailApp {
           ],
         },
       );
-      await recordCheckpointGraphCompletion(run, session, async () => {
-        await this.materializeAssistantDeliveriesForRun(runId, run);
-        await this.persistRun(runId, run);
-      });
+      await recordCheckpointGraphCompletion(
+        run,
+        session,
+        checkpoint.cursor + consumedInSlice,
+        async () => {
+          await this.materializeAssistantDeliveriesForRun(runId, run);
+          await this.persistRun(runId, run);
+        },
+      );
       return { status: 'done', runId, session };
     } catch (error) {
       if (error instanceof GraphExecutionSuspended) {
@@ -1489,6 +1501,7 @@ export class PromptTrailApp {
           run,
           error.nodePath,
           session,
+          checkpoint.cursor + consumedInSlice,
           () => this.persistRun(runId, run),
         );
         return {

--- a/packages/core/src/graph_executor.ts
+++ b/packages/core/src/graph_executor.ts
@@ -74,6 +74,13 @@ export interface GraphExecutionOptions<TVars extends Vars = Vars> {
   ) => Promise<void>;
   runEventSource?: ExecutionEvent['source'];
   unsupportedCommandLabel?: string;
+  /**
+   * Invoked whenever an inbox message is consumed, with the running count of
+   * consumed messages (the executor's inbox cursor). Callers use the final
+   * value to persist a durable inbox cursor that never runs ahead of the
+   * session the graph actually produced. See the checkpoint continuation model.
+   */
+  onInboxConsumed?: (consumedCount: number) => void;
 }
 
 export interface GraphToolDurableBoundaryContext<TVars extends Vars = Vars> {
@@ -131,6 +138,7 @@ interface GraphExecutionState<TVars extends Vars> {
   runEventSource: ExecutionEvent['source'];
   unsupportedCommandLabel?: string;
   activeGoal?: ActiveGoalExecution;
+  onInboxConsumed?: (consumedCount: number) => void;
 }
 
 type GraphNodeData = Record<string, unknown>;
@@ -220,6 +228,7 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
     durableToolExecution: options.durableToolExecution,
     runEventSource: options.runEventSource ?? 'graph',
     unsupportedCommandLabel: options.unsupportedCommandLabel,
+    onInboxConsumed: options.onInboxConsumed,
   };
 
   await emitGraphRunEvent('run.started', state, {
@@ -1305,6 +1314,7 @@ function consumeInbox<TVars extends Vars>(
     return false;
   }
   state.cursor += 1;
+  state.onInboxConsumed?.(state.cursor);
   const kind = inbound.kind ?? 'user';
   if (inbound.kind === 'system') {
     state.session = state.session.addMessage(


### PR DESCRIPTION
Last of the correctness defects from the durable-runtime review series (#51, #53, #54, #55, #59).

beginCheckpointGraphExecution persisted graphCursor=inbox.length BEFORE running the graph. Thrown errors are rolled back (#53), but a hard crash mid-execution leaves the persisted cursor ahead of the session — a cold restart then skips unprocessed input (at-least-once violation, silent loss).

- cursor no longer persists pre-execution; it advances only inside the suspension/completion persist, to the executor's actual consumed count (new onInboxConsumed feedback from consumeInbox — correct through subroutines and the completion drain)
- (graphCursor, session) now mutually consistent at every rest point; crash recovery re-delivers the unconsumed tail, deduped by effect declarations/once-memo as designed
- checkpoint_continuation.ts model doc rewritten to state the contract
- crash test: snapshot durable state mid-execution → rehydrate fresh app → input preserved; verified the test fails with the optimistic advance reintroduced

core 736 unit tests (+3), discord 16, cron 10, typecheck + prettier green.