### PR TITLE
feat: orphan auto-resume (durability §2.1 — crash recovery on boot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ directly. `checkpoint: true` uses the ambient app store (and fails fast with
 guidance when there is none). Stores persist session _deltas_ — appended
 messages and var diffs — not full-session rewrites.
 
+**Crash recovery (orphan auto-resume).** `PromptTrail.app({ recovery: true })`
+scans the run store on boot and resumes runs that were mid-execution when a
+process died — a run whose inbox has an unconsumed tail (`graphCursor <
+inbox.length`), the durable signal that work was delivered but never finished.
+No human re-invocation, no lost input. Pass `{ intervalMs }` to also rescan
+periodically, and `onError` to observe a resume that throws (the scan continues
+regardless). A run legitimately suspended at `awaitInput` has consumed its inbox
+and is left waiting, not resumed. Recovery re-delivers only the unconsumed tail,
+so it is **at-least-once** like every resume — deduped by your declared effect
+idempotency keys. Compose it with `lease` for cross-process single-writer
+safety; the boot scan runs only after the lease is acquired.
+
 The guarantee is honest and intentionally limited:
 
 - Checkpoint resume gives **at-least-once** effect execution: completed nodes

--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -1719,6 +1719,221 @@ describe('checkpoint app lease mode', () => {
   });
 });
 
+describe('checkpoint app orphan auto-resume (crash recovery)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const buildRecoverable = () =>
+    Agent.create('recover')
+      .inbox('in')
+      .assistant('reply', Source.literal('ok'));
+
+  // The exact durable state a hard crash mid-execution leaves under the
+  // checkpoint persistence contract: the inbox holds the delivered input but the
+  // cursor never advanced (graphCursor 0 < inbox.length 1) and no session was
+  // produced. See "does not lose inbox input when the process crashes".
+  const makeOrphan = (agentName = 'recover'): StoredRun<any> => ({
+    agent: buildRecoverable(),
+    agentName,
+    initial: Session.create(),
+    status: 'open',
+    once: createCheckpointOnceMemoStore(),
+    outbox: [],
+    inbox: [{ offset: 0, kind: 'user', content: 'hello' }],
+    providerSessions: {},
+    graphCursor: 0,
+  });
+
+  it('resumes an orphan on start() with no send, driving it to completion', async () => {
+    const store = new MemoryRunStore();
+    await store.create('run-orphan', makeOrphan());
+
+    const app = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      recovery: true,
+    });
+    await app.start();
+
+    const recovered = await store.get('run-orphan');
+    expect(recovered?.status).toBe('done');
+    expect(
+      recovered?.result?.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ok']);
+    await app.stop();
+  });
+
+  it('does not resume a run suspended at awaitInput (inbox fully consumed)', async () => {
+    const store = memoryStore();
+    const build = () =>
+      Agent.create('awaiter')
+        .inbox('in')
+        .assistant('ack', Source.literal('ack'))
+        .awaitInput('more')
+        .assistant('final', Source.literal('final'));
+    const producer = PromptTrail.app({ agents: { awaiter: build() }, store });
+    const suspended = await producer.run({
+      agent: 'awaiter',
+      runId: 'run-await',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(suspended.status).toBe('suspended');
+    const before = await store.get('run-await');
+    // The consumed inbox tail is the discriminator: cursor === inbox.length.
+    expect(before?.graphCursor).toBe(before?.inbox.length);
+
+    const recoverer = PromptTrail.app({
+      agents: { awaiter: build() },
+      store,
+      recovery: true,
+    });
+    await recoverer.start();
+
+    const after = await store.get('run-await');
+    // Still suspended and NOT advanced to the final assistant.
+    expect(after?.status).toBe('open');
+    expect(after?.graphSuspendedAt).toBeDefined();
+    expect(after?.result?.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ack',
+    ]);
+    await recoverer.stop();
+  });
+
+  it('leaves completed runs untouched', async () => {
+    const store = memoryStore();
+    const producer = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+    });
+    const done = await producer.run({
+      agent: 'recover',
+      runId: 'run-done',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(done.status).toBe('done');
+    const before = await store.get('run-done');
+
+    const recoverer = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      recovery: true,
+    });
+    await recoverer.start();
+
+    const after = await store.get('run-done');
+    expect(after?.status).toBe('done');
+    expect(after?.result?.messages.map((message) => message.content)).toEqual(
+      before?.result?.messages.map((message) => message.content),
+    );
+    await recoverer.stop();
+  });
+
+  it('reports a failing orphan resume via onError and continues the scan', async () => {
+    const store = new MemoryRunStore();
+    // First orphan names an unregistered agent -> its resume throws.
+    await store.create('run-bad', makeOrphan('missing-agent'));
+    // Second orphan is recoverable and must still complete.
+    await store.create('run-good', makeOrphan('recover'));
+
+    const errors: Array<{ runId: string; error: unknown }> = [];
+    const app = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      recovery: {
+        onStart: true,
+        onError: (runId, error) => errors.push({ runId, error }),
+      },
+    });
+    await app.start();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].runId).toBe('run-bad');
+    const good = await store.get('run-good');
+    expect(good?.status).toBe('done');
+    expect(good?.result?.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'ok',
+    ]);
+    await app.stop();
+  });
+
+  it('picks up an orphan that appears after start via the periodic scan', async () => {
+    vi.useFakeTimers();
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      recovery: { intervalMs: 1_000 },
+    });
+    await app.start();
+
+    // No orphan at boot; the run appears later (e.g. a crash on another node
+    // that shared this store, or a run this instance abandoned).
+    await store.create('run-late', makeOrphan());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const recovered = await store.get('run-late');
+    expect(recovered?.status).toBe('done');
+    expect(
+      recovered?.result?.messages.map((message) => message.content),
+    ).toEqual(['hello', 'ok']);
+    await app.stop();
+  });
+
+  it('recovers orphans under lease mode only after acquiring the lease', async () => {
+    const store = new MemoryRunStore();
+    await store.create('run-leased-orphan', makeOrphan());
+    const app = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      lease: { holder: 'A', ttlMs: 10_000 },
+      recovery: true,
+    });
+    // A pre-start recovery would hit requireFence() (no lease yet); reaching
+    // completion proves the scan ran AFTER acquire and its writes carry the fence.
+    await app.start();
+    const recovered = await store.get('run-leased-orphan');
+    expect(recovered?.status).toBe('done');
+    expect(app_holder(app.lease)).toBe('A');
+    await app.stop();
+  });
+
+  it('does not scan when the instance cannot acquire the lease', async () => {
+    const store = new MemoryRunStore();
+    await store.create('run-orphan', makeOrphan());
+
+    const holder = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      lease: { holder: 'A', ttlMs: 10_000 },
+    });
+    await holder.start();
+
+    const contender = PromptTrail.app({
+      agents: { recover: buildRecoverable() },
+      store,
+      lease: { holder: 'B', ttlMs: 10_000 },
+      recovery: true,
+    });
+    await expect(contender.start()).rejects.toBeInstanceOf(
+      LeaseUnavailableError,
+    );
+
+    // The instance that lost the lease race never touched the orphan.
+    const untouched = await store.get('run-orphan');
+    expect(untouched?.status).toBe('open');
+    expect(untouched?.graphCursor ?? 0).toBe(0);
+    expect(untouched?.result).toBeUndefined();
+
+    await holder.stop();
+    await contender.stop();
+  });
+});
+
 function app_holder(state: RunStoreLeaseState | undefined): string | undefined {
   return state?.holder;
 }

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -676,6 +676,39 @@ export interface LeaseOptions {
 }
 
 /**
+ * Options for opt-in orphan auto-resume (crash recovery) on
+ * {@link PromptTrailApp}. See {@link PromptTrailAppOptions.recovery}.
+ *
+ * An "orphan" is a run that was mid-execution when its process died: work was
+ * delivered to it (appended to the inbox) but never fully consumed. Under the
+ * checkpoint persistence contract (see {@link module:checkpoint_continuation}),
+ * the inbox cursor advances only at a terminal boundary (completion/suspension),
+ * so a run that crashed mid-execution rests with `graphCursor < inbox.length` —
+ * an UNCONSUMED INBOX TAIL. That durable signal — not any status flag — is the
+ * recoverable truth: the status vocabulary is only `'open' | 'done'`, and a run
+ * legitimately suspended at `awaitInput` also rests as `'open'`, but with a
+ * FULLY-consumed inbox (`graphCursor === inbox.length`), so it is NOT an orphan.
+ * Re-resuming an orphan re-delivers only the still-unconsumed tail, which is
+ * at-least-once and deduped by declared effect idempotency keys / the once memo.
+ */
+export interface RecoveryOptions {
+  /** Scan and resume orphans once when {@link PromptTrailApp.start} runs. */
+  onStart?: boolean;
+  /**
+   * Also scan periodically every `intervalMs` while the app is running. The
+   * timer is unref'd (never keeps the process alive) and cleared on `stop()`.
+   * Omit for a boot-only scan.
+   */
+  intervalMs?: number;
+  /**
+   * Invoked when resuming a single orphan throws. A failure never aborts the
+   * scan — the remaining orphans are still attempted. Defaults to
+   * `console.warn`.
+   */
+  onError?: (runId: string, error: unknown) => void;
+}
+
+/**
  * Thrown by `app.start()` when lease mode is enabled but a LIVE lease is already
  * held by a different writer. v1 is fail-fast: there is no waiting/polling — a
  * new instance may only take over once the current holder releases or its lease
@@ -855,6 +888,21 @@ export interface PromptTrailAppOptions {
    * stopped and subsequent writes throw {@link FencingTokenError}.
    */
   onLeaseLost?: (state: RunStoreLeaseState | undefined) => void;
+  /**
+   * Opt-in orphan auto-resume (crash recovery). `true` enables a boot-only scan
+   * (`{ onStart: true }`); an object also allows a periodic scan via
+   * `intervalMs`. On `start()` — AFTER the store lease is acquired when lease
+   * mode is on, so a scan never runs on an instance that lost the lease race —
+   * the app scans the run store for orphans (runs with an unconsumed inbox tail,
+   * `graphCursor < inbox.length`) and resumes each through the normal per-run
+   * locked path, sequentially; a resume that suspends again is a normal outcome
+   * and a resume that throws goes to `onError` without aborting the scan.
+   *
+   * With lease mode on, recovery composes naturally: this instance is the sole
+   * writer. WITHOUT lease mode the operator owns single-writer discipline —
+   * running two recovering instances against one store may double-resume.
+   */
+  recovery?: RecoveryOptions | true;
   defaults?: BindingDefaults;
   agents?: Record<string, PromptTrailRegisteredAgent<any>>;
   gateways?: Record<string, AppGateway>;
@@ -887,6 +935,12 @@ export class PromptTrailApp {
   private leaseState?: RunStoreLeaseState;
   private leaseLost = false;
   private heartbeatTimer?: ReturnType<typeof setInterval>;
+  private readonly recoveryConfig?: {
+    onStart: boolean;
+    intervalMs?: number;
+    onError: (runId: string, error: unknown) => void;
+  };
+  private recoveryTimer?: ReturnType<typeof setInterval>;
   private readonly agents = new Map<string, Agent<any>>();
   private readonly gateways = new Map<string, AppGateway>();
   private readonly runtimeBindings: RuntimeBinding<TriggerEvent>[] = [];
@@ -953,6 +1007,21 @@ export class PromptTrailApp {
       );
     } else {
       this.store = this.baseStore;
+    }
+    if (options.recovery) {
+      const recoveryOpts =
+        options.recovery === true ? { onStart: true } : options.recovery;
+      this.recoveryConfig = {
+        onStart: recoveryOpts.onStart ?? false,
+        intervalMs: recoveryOpts.intervalMs,
+        onError:
+          recoveryOpts.onError ??
+          ((runId, error) =>
+            console.warn(
+              `[PromptTrail] app "${this.name}" failed to auto-resume orphan run "${runId}":`,
+              error,
+            )),
+      };
     }
     this.runtimeDefaults = options.defaults ?? {};
     this.defaultCheckpoint = options.defaults?.checkpoint;
@@ -1289,6 +1358,14 @@ export class PromptTrailApp {
     // Acquire the store lease before anything writes (runtime-server startup
     // retries deliveries, gateways may emit) so all writes carry the fence.
     await this.acquireLease();
+    // Orphan auto-resume runs only past a successful lease acquisition, so an
+    // instance that lost the lease race (acquireLease threw) never recovers.
+    // Boot-scan before adapters start so recovered outbox deliveries are already
+    // queued when the runtime server begins retrying pending deliveries.
+    if (this.recoveryConfig?.onStart) {
+      await this.recoverOrphans();
+    }
+    this.startRecoveryTimer();
     if (this.runtimeAdapters.length > 0) {
       if (!this.runtimeServer) {
         this.runtimeServer = server({
@@ -1309,12 +1386,97 @@ export class PromptTrailApp {
   }
 
   async stop(): Promise<void> {
+    this.stopRecoveryTimer();
     await this.runtimeServer?.stop();
     this.runtimeServer = undefined;
     for (const gateway of this.gateways.values()) {
       await gateway.stop?.();
     }
     await this.releaseLease();
+  }
+
+  /**
+   * True when a stored run is an orphan: it never reached a terminal boundary
+   * for its most recently delivered inbox (`graphCursor < inbox.length`) and is
+   * not a completed run. Under the checkpoint persistence contract the cursor
+   * advances only at completion/suspension, so an unconsumed inbox tail is the
+   * durable signal that a process died mid-execution. A run suspended at
+   * `awaitInput` has consumed its inbox tail (cursor === inbox.length) and is
+   * therefore NOT an orphan — it is legitimately waiting for the next input.
+   */
+  private isOrphanRun(run: StoredRun<any>): boolean {
+    return run.status !== 'done' && (run.graphCursor ?? 0) < run.inbox.length;
+  }
+
+  /**
+   * Scan the run store and resume every orphan sequentially through the normal
+   * per-run locked resume path (so recovery never collides with a concurrent
+   * send for the same run). Each resume failure is reported to the configured
+   * `onError` and does NOT abort the scan; a resume that suspends again is a
+   * normal outcome. A lost lease short-circuits the scan.
+   */
+  private async recoverOrphans(): Promise<void> {
+    if (!this.recoveryConfig || this.leaseLost) {
+      return;
+    }
+    const orphanIds: string[] = [];
+    for (const [runId, run] of await this.store.entries()) {
+      if (this.isOrphanRun(run)) {
+        orphanIds.push(runId);
+      }
+    }
+    for (const runId of orphanIds) {
+      try {
+        await this.resumeOrphan(runId);
+      } catch (error) {
+        this.recoveryConfig.onError(runId, error);
+      }
+    }
+  }
+
+  /**
+   * Resume a single orphan under its per-run mutex. Re-checks the orphan
+   * condition under the lock (a concurrent send may have already advanced it)
+   * and rebinds the agent from the registry by `agentName` so recovery works
+   * after a cold restart where the stored run carries no live agent reference.
+   */
+  private async resumeOrphan(runId: string): Promise<void> {
+    await this.runLocks.run(runId, async () => {
+      const run = await this.store.get(runId);
+      if (!run || !this.isOrphanRun(run)) {
+        return;
+      }
+      const agent = this.agents.get(run.agentName);
+      if (!agent) {
+        throw new Error(
+          `Cannot auto-resume orphan run "${runId}": no agent named ` +
+            `"${run.agentName}" is registered on app "${this.name}".`,
+        );
+      }
+      run.agent = agent;
+      await this.resumeImpl(runId);
+    });
+  }
+
+  private startRecoveryTimer(): void {
+    const intervalMs = this.recoveryConfig?.intervalMs;
+    if (!intervalMs) {
+      return;
+    }
+    this.stopRecoveryTimer();
+    const timer = setInterval(() => {
+      void this.recoverOrphans();
+    }, intervalMs);
+    // Don't keep the process alive purely for the recovery scan.
+    timer.unref?.();
+    this.recoveryTimer = timer;
+  }
+
+  private stopRecoveryTimer(): void {
+    if (this.recoveryTimer !== undefined) {
+      clearInterval(this.recoveryTimer);
+      this.recoveryTimer = undefined;
+    }
   }
 
   async run<TVars extends Vars = Vars>(


### PR DESCRIPTION
The roadmap differentiator: 'OSS LangGraph requires a human to re-invoke; doing this automatically is a real differentiator.'

- `recovery: true | { onStart, intervalMs, onError }` on PromptTrail.app
- Orphan discriminator: status ≠ done AND graphCursor < inbox.length — the durable 'delivered but never finished' signal under #60's terminal-boundary cursor contract; awaitInput-suspended runs (consumed inbox) are correctly left waiting
- Boot scan runs after lease acquisition (#61) so a fenced-out instance never recovers; sequential resumes through the locked resume path, agent rebound by name (cold-restart safe); failures → onError, scan continues; optional periodic rescan (unref'd, cleared on stop)
- README: crash-recovery paragraph, honest at-least-once tone

7 new tests incl. snapshot-rehydrate crash sim (completes with no send), suspended-run non-resume, onError continuation, fake-timer periodic pickup, lease composition. core 748 unit / claw 8 / typecheck / prettier green.