### PR TITLE
feat: durable timers (roadmap durability §3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ runtime warns at registration when a resume-sensitive node (such as
 The full vocabulary:
 
 - Leaf nodes: `system`, `user`, `assistant`, `transform`, `inbox`,
-  `awaitInput`, `tools`, `structured`
+  `awaitInput`, `sleep`, `tools`, `structured`
 - Containers: `loop`, `conditional`, `subroutine`, `parallel`
 - Intent and provider turns: `goal`, `codex`, `claude`
 
@@ -229,6 +229,29 @@ and is left waiting, not resumed. Recovery re-delivers only the unconsumed tail,
 so it is **at-least-once** like every resume — deduped by your declared effect
 idempotency keys. Compose it with `lease` for cross-process single-writer
 safety; the boot scan runs only after the lease is acquired.
+
+**Durable timers (`sleep`).** `.sleep(id, duration)` suspends a run for a wall
+clock delay that survives restarts. The wake-at is persisted with the run, and
+`PromptTrail.app` re-arms it on boot — a `sleep('7d')` that is halfway through
+when the process dies still fires when its time comes, with no human
+re-invocation. `duration` is milliseconds or a human string (`'2h'`, `'7d'`,
+`'1h30m'`).
+
+```ts
+const reminder = Agent.create('reminder')
+  .sleep('wait', '7d')
+  .assistant('nudge', Source.llm());
+// run suspends at 'reminder/wait'; a week later the app's timer sweep resumes
+// it past the sleep and the assistant delivers.
+```
+
+The sweep is always on when the app has a store: it holds a single in-process
+timer that wakes at the earliest pending wake-at and re-arms after each firing
+(no per-timer OS timer, nothing held at rest), sharing the discipline of the
+`@prompttrail/cron` gateway rather than a second scheduler. Firing marks the
+timer and resumes through the same locked, fenced path as any resume, so the
+at-least-once contract below is unchanged. Under ephemeral (non-checkpoint)
+execution, `sleep` is a plain in-process wait.
 
 The guarantee is honest and intentionally limited:
 

--- a/examples/readme_snippets.ts
+++ b/examples/readme_snippets.ts
@@ -111,6 +111,15 @@ const done = await checkpointSupport.execute({
 });
 console.log(done.status, done.session.getLastMessage()?.content);
 
+// --- Durable timers (sleep) ----------------------------------------------
+
+const reminder = Agent.create('reminder')
+  .sleep('wait', '7d')
+  .assistant('nudge', Source.llm());
+// run suspends at 'reminder/wait'; a week later the app's timer sweep resumes
+// it past the sleep and the assistant delivers.
+void reminder;
+
 // --- Vendor Tool Loops ---------------------------------------------------
 
 void Source.llm().openai().toolLoop('vendor').addTool('searchDocs', searchDocs);

--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -17,6 +17,7 @@ import type { RunStoreLeaseState } from '../../durable';
 import type {
   AssistantDeliveryOutboxEntry,
   DurableRunStore,
+  DurableTimer,
   Inbound,
   OnceScope,
   SessionCheckpointDelta,
@@ -167,6 +168,10 @@ class TrackingRunStore implements DurableRunStore {
     });
   }
 
+  async upsertTimer(runId: string, timer: DurableTimer): Promise<void> {
+    upsertTimer(this.runs.get(runId), timer);
+  }
+
   async delete(runId: string): Promise<void> {
     this.runs.delete(runId);
   }
@@ -288,6 +293,15 @@ class ControlledDelayRunStore implements DurableRunStore {
     return this.delayWrite('recordProviderSession', runId, run, () => {});
   }
 
+  upsertTimer(runId: string, timer: DurableTimer): Promise<void> {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return Promise.resolve();
+    }
+    upsertTimer(run, timer);
+    return this.delayWrite('upsertTimer', runId, run, () => {});
+  }
+
   async delete(runId: string): Promise<void> {
     this.runs.delete(runId);
   }
@@ -357,6 +371,7 @@ type RecordedWrite =
       nodePath: string;
       binding: ProviderSessionBinding;
     }
+  | { type: 'upsertTimer'; runId: string }
   | { type: 'delete'; runId: string };
 
 class RecordingRunStore implements DurableRunStore {
@@ -467,6 +482,15 @@ class RecordingRunStore implements DurableRunStore {
       nodePath,
       binding,
     });
+  }
+
+  async upsertTimer(runId: string, timer: DurableTimer): Promise<void> {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    upsertTimer(run, timer);
+    this.writes.push({ type: 'upsertTimer', runId });
   }
 
   async delete(runId: string): Promise<void> {
@@ -2021,5 +2045,21 @@ function upsertOutbox(
     run.outbox[index] = entry;
   } else {
     run.outbox.push(entry);
+  }
+}
+
+function upsertTimer(
+  run: StoredRun<any> | undefined,
+  timer: DurableTimer,
+): void {
+  if (!run) {
+    return;
+  }
+  const timers = (run.timers ??= []);
+  const index = timers.findIndex((candidate) => candidate.id === timer.id);
+  if (index >= 0) {
+    timers[index] = timer;
+  } else {
+    timers.push(timer);
   }
 }

--- a/packages/core/src/__tests__/unit/durable_timers.test.ts
+++ b/packages/core/src/__tests__/unit/durable_timers.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PromptTrail, memoryStore } from '../../durable';
+import { parseDuration } from '../../duration';
+import { Source } from '../../source';
+import { Agent } from '../../templates';
+
+const HOUR = 3_600_000;
+
+function reminderAgent() {
+  // A minimal durable-reminder shape: sleep, then emit a fixed reply. Literal
+  // sources keep it deterministic (no real model call).
+  return Agent.create('reminder')
+    .sleep('wait', '2h')
+    .assistant('done', Source.literal('reminder fired'));
+}
+
+describe('durable timers — Agent.sleep', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('suspends with the timer persisted, then fires and completes on advance', async () => {
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    await app.start();
+
+    const base = Date.now();
+    const suspended = await app.run({
+      agent: 'reminder',
+      runId: 'r-sleep',
+      checkpoint: true,
+    });
+    expect(suspended.status).toBe('suspended');
+    expect(suspended.awaiting).toBe('reminder/wait');
+
+    // Timer persisted, pending, with wakeAt = now + 2h.
+    const armed = await store.get('r-sleep');
+    expect(armed!.timers).toHaveLength(1);
+    expect(armed!.timers![0].id).toBe('reminder/wait');
+    expect(armed!.timers![0].wakeAt).toBe(base + 2 * HOUR);
+    expect(armed!.timers![0].firedAt).toBeUndefined();
+
+    // Not yet due: advancing less than the duration does not fire.
+    await vi.advanceTimersByTimeAsync(HOUR);
+    expect((await store.get('r-sleep'))!.status).toBe('open');
+
+    // Crossing wakeAt fires the sweep, which resumes the run past the sleep.
+    await vi.advanceTimersByTimeAsync(HOUR);
+    const done = await store.get('r-sleep');
+    expect(done!.status).toBe('done');
+    expect(done!.timers![0].firedAt).toBeDefined();
+    expect(done!.result!.messages.map((message) => message.content)).toContain(
+      'reminder fired',
+    );
+
+    await app.stop();
+  });
+
+  it('a fresh app on the same store re-arms a pending timer and fires it (cold restart)', async () => {
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    await app.start();
+    await app.run({ agent: 'reminder', runId: 'r-cold', checkpoint: true });
+    // Simulate a restart: stop the first app (its sweep timer is cleared) with
+    // the timer still pending.
+    await app.stop();
+    expect((await store.get('r-cold'))!.timers![0].firedAt).toBeUndefined();
+
+    const restarted = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    // Boot scan re-arms the pending (future) timer; advancing time fires it.
+    await restarted.start();
+    expect((await store.get('r-cold'))!.status).toBe('open');
+    await vi.advanceTimersByTimeAsync(2 * HOUR);
+
+    const done = await store.get('r-cold');
+    expect(done!.status).toBe('done');
+    expect(done!.timers![0].firedAt).toBeDefined();
+    await restarted.stop();
+  });
+
+  it('fires a past-due timer immediately on start (cold-boot fire)', async () => {
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    await app.start();
+    await app.run({ agent: 'reminder', runId: 'r-due', checkpoint: true });
+    await app.stop();
+
+    // Advance the wall clock past wakeAt WITHOUT running the (now-cleared) sweep.
+    vi.setSystemTime(Date.now() + 3 * HOUR);
+
+    const restarted = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    // The boot sweep sees wakeAt <= now and fires synchronously during start().
+    await restarted.start();
+
+    const done = await store.get('r-due');
+    expect(done!.status).toBe('done');
+    expect(done!.timers![0].firedAt).toBeDefined();
+    await restarted.stop();
+  });
+
+  it('does not re-arm after firing — a fired timer stays single-shot', async () => {
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+    });
+    await app.start();
+    await app.run({ agent: 'reminder', runId: 'r-once', checkpoint: true });
+    await vi.advanceTimersByTimeAsync(2 * HOUR);
+
+    const done = await store.get('r-once');
+    expect(done!.status).toBe('done');
+    expect(done!.timers).toHaveLength(1);
+    const firedAt = done!.timers![0].firedAt;
+    expect(firedAt).toBeDefined();
+
+    // Resuming a completed sleep run must not re-arm the timer or change firedAt,
+    // and it must not spin (advancing time fires nothing new).
+    const resumed = await app.resume('r-once');
+    expect(resumed.status).toBe('done');
+    await vi.advanceTimersByTimeAsync(10 * HOUR);
+    const after = await store.get('r-once');
+    expect(after!.timers).toHaveLength(1);
+    expect(after!.timers![0].firedAt).toBe(firedAt);
+
+    await app.stop();
+  });
+
+  it('fires through the fenced store under lease mode', async () => {
+    // With lease mode on, every store mutation carries the lease fencing token.
+    // If the timer-firing writes (upsertTimer + the resume's checkpoint writes)
+    // did NOT present the fence, the FencedRunStore would reject them with a
+    // FencingTokenError and the run would never complete — so a clean fire+
+    // complete under an active lease proves the firing path is fenced.
+    const store = memoryStore();
+    const app = PromptTrail.app({
+      agents: { reminder: reminderAgent() },
+      store,
+      lease: true,
+    });
+    await app.start();
+    expect(app.lease).toBeDefined();
+
+    await app.run({ agent: 'reminder', runId: 'r-fenced', checkpoint: true });
+    await vi.advanceTimersByTimeAsync(2 * HOUR);
+
+    const done = await store.get('r-fenced');
+    expect(done!.status).toBe('done');
+    expect(done!.timers![0].firedAt).toBeDefined();
+    await app.stop();
+  });
+});
+
+describe('parseDuration', () => {
+  it('passes through non-negative numbers as milliseconds', () => {
+    expect(parseDuration(0)).toBe(0);
+    expect(parseDuration(1500)).toBe(1500);
+  });
+
+  it('parses single-unit strings', () => {
+    expect(parseDuration('500ms')).toBe(500);
+    expect(parseDuration('90s')).toBe(90_000);
+    expect(parseDuration('30m')).toBe(1_800_000);
+    expect(parseDuration('2h')).toBe(7_200_000);
+    expect(parseDuration('7d')).toBe(604_800_000);
+    expect(parseDuration('1w')).toBe(604_800_000);
+  });
+
+  it('parses compound strings and tolerates whitespace', () => {
+    expect(parseDuration('1h30m')).toBe(5_400_000);
+    expect(parseDuration('1h 30m')).toBe(5_400_000);
+    expect(parseDuration('2d12h')).toBe(216_000_000);
+  });
+
+  it('rejects invalid input', () => {
+    expect(() => parseDuration('')).toThrow();
+    expect(() => parseDuration('7dd')).toThrow();
+    expect(() => parseDuration('abc')).toThrow();
+    expect(() => parseDuration('10y')).toThrow();
+    expect(() => parseDuration(-5)).toThrow();
+    expect(() => parseDuration(Number.NaN)).toThrow();
+  });
+});

--- a/packages/core/src/__tests__/unit/public_api.test.ts
+++ b/packages/core/src/__tests__/unit/public_api.test.ts
@@ -76,6 +76,7 @@ describe('public API surface', () => {
       'manifestConfigDigest',
       'memoryStore',
       'on',
+      'parseDuration',
       'validateAgentGraph',
     ]);
   });

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -77,6 +77,34 @@ export interface ToolCall {
   id: string;
 }
 
+/**
+ * A durable timer armed by a `sleep` node (durability roadmap §3). Persisted on
+ * the run so a scheduler can re-arm it after a restart and fire it even across a
+ * cold boot.
+ *
+ * Identity is `(runId, id)`: `id` is the sleep node's graph path, so arming is
+ * idempotent — re-executing the same sleep node never resets an already-armed
+ * `wakeAt`. `firedAt` is set once the app fires the timer (marks it and resumes
+ * the run); a fired timer is never re-armed. `kind`/`payload` describe how the
+ * timer wakes the run — v1 sleep always uses a `control` marker recognized via
+ * the executor's fired-timer set, and the fields are reserved for external
+ * signals that carry a payload.
+ */
+export interface DurableTimer {
+  /** Stable timer id — the sleep node's graph path. Unique per run. */
+  id: string;
+  /** Absolute wake time, epoch milliseconds. */
+  wakeAt: number;
+  /** Optional payload delivered when the timer fires (reserved for signals). */
+  payload?: string;
+  /** Inbound kind used when the timer wakes the run. Defaults to `control`. */
+  kind?: InboundKind;
+  /** When the timer was armed, epoch milliseconds. */
+  createdAt: number;
+  /** When the timer fired, epoch milliseconds; unset while still pending. */
+  firedAt?: number;
+}
+
 export interface DurableRunResult<TVars extends Vars = Vars> {
   status: 'done' | 'suspended';
   runId: string;
@@ -138,6 +166,7 @@ export interface StoredRun<TVars extends Vars> {
   outbox: AssistantDeliveryOutboxEntry[];
   inbox: Inbound[];
   providerSessions?: Record<string, ProviderSessionBinding>;
+  timers?: DurableTimer[];
   graphCursor?: number;
   graphSuspendedAt?: string;
   context?: Record<string, unknown>;
@@ -511,6 +540,17 @@ export interface DurableRunStore {
     binding: ProviderSessionBinding,
     fence?: number,
   ): Promise<void>;
+  /**
+   * Arm or update a durable timer (durability roadmap §3). Idempotent by
+   * `(runId, timer.id)`: a second upsert with the same id REPLACES the row (used
+   * to mark `firedAt`), it does not append a duplicate. Timers are included in
+   * `get`/`entries` reconstruction and removed by `delete`'s cascade.
+   */
+  upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void>;
   delete(runId: string, fence?: number): Promise<void>;
 }
 
@@ -646,6 +686,25 @@ export class MemoryRunStore implements DurableRunStore {
       ...(run.providerSessions ?? {}),
       [nodePath]: binding,
     };
+  }
+
+  async upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    const timers = (run.timers ??= []);
+    const index = timers.findIndex((candidate) => candidate.id === timer.id);
+    if (index >= 0) {
+      timers[index] = timer;
+    } else {
+      timers.push(timer);
+    }
   }
 
   async delete(runId: string, fence?: number): Promise<void> {
@@ -847,6 +906,16 @@ class FencedRunStore implements DurableRunStore {
     );
   }
 
+  upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    return this.guard(() =>
+      this.inner.upsertTimer(runId, timer, fence ?? this.fence()),
+    );
+  }
+
   delete(runId: string, fence?: number): Promise<void> {
     return this.guard(() => this.inner.delete(runId, fence ?? this.fence()));
   }
@@ -903,6 +972,17 @@ export interface PromptTrailAppOptions {
    * running two recovering instances against one store may double-resume.
    */
   recovery?: RecoveryOptions | true;
+  /**
+   * Injectable clock (epoch ms) for the durable-timer sweep (durability roadmap
+   * §3). Defaults to `Date.now`. Tests fake it (e.g. vitest fake timers) so
+   * timer wake-ups can be driven without sleeping; production leaves it default.
+   */
+  now?: () => number;
+  /**
+   * Invoked when firing a single due timer throws. A failure never aborts the
+   * sweep — remaining due timers are still attempted. Defaults to `console.warn`.
+   */
+  onTimerError?: (runId: string, timerId: string, error: unknown) => void;
   defaults?: BindingDefaults;
   agents?: Record<string, PromptTrailRegisteredAgent<any>>;
   gateways?: Record<string, AppGateway>;
@@ -941,6 +1021,15 @@ export class PromptTrailApp {
     onError: (runId: string, error: unknown) => void;
   };
   private recoveryTimer?: ReturnType<typeof setInterval>;
+  private readonly now: () => number;
+  private readonly onTimerError: (
+    runId: string,
+    timerId: string,
+    error: unknown,
+  ) => void;
+  private timerSweepHandle?: ReturnType<typeof setTimeout>;
+  private timerSweepInFlight = false;
+  private timerSweepStopped = false;
   private readonly agents = new Map<string, Agent<any>>();
   private readonly gateways = new Map<string, AppGateway>();
   private readonly runtimeBindings: RuntimeBinding<TriggerEvent>[] = [];
@@ -1023,6 +1112,14 @@ export class PromptTrailApp {
             )),
       };
     }
+    this.now = options.now ?? Date.now;
+    this.onTimerError =
+      options.onTimerError ??
+      ((runId, timerId, error) =>
+        console.warn(
+          `[PromptTrail] app "${this.name}" failed to fire durable timer "${timerId}" on run "${runId}":`,
+          error,
+        ));
     this.runtimeDefaults = options.defaults ?? {};
     this.defaultCheckpoint = options.defaults?.checkpoint;
     this.middleware = options.middleware ?? [];
@@ -1366,6 +1463,12 @@ export class PromptTrailApp {
       await this.recoverOrphans();
     }
     this.startRecoveryTimer();
+    // Durable-timer sweep (durability roadmap §3): always on with a store. The
+    // boot sweep fires any timer already due (including cold-boot/past-due) and
+    // arms an in-process wake for the earliest still-pending one. It runs after
+    // recovery so a resumed orphan's freshly-armed timers are already visible.
+    this.timerSweepStopped = false;
+    await this.runTimerSweep();
     if (this.runtimeAdapters.length > 0) {
       if (!this.runtimeServer) {
         this.runtimeServer = server({
@@ -1387,6 +1490,7 @@ export class PromptTrailApp {
 
   async stop(): Promise<void> {
     this.stopRecoveryTimer();
+    this.stopTimerSweep();
     await this.runtimeServer?.stop();
     this.runtimeServer = undefined;
     for (const gateway of this.gateways.values()) {
@@ -1477,6 +1581,162 @@ export class PromptTrailApp {
       clearInterval(this.recoveryTimer);
       this.recoveryTimer = undefined;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Durable timer sweep (durability roadmap §3)
+  //
+  // Design: ONE self-driven sweep timer, not a fixed poll interval and not one
+  // OS timer per pending durable timer. `runTimerSweep` fires every timer that
+  // is due now (`wakeAt <= now`), then re-arms a single in-process `setTimeout`
+  // that wakes at the EARLIEST still-pending `wakeAt` across all runs; each fire
+  // re-runs the sweep, which re-arms for the next earliest. When no timer is
+  // pending, no OS timer is held, so the sweep costs nothing at rest. The handle
+  // is unref'd (never keeps the process alive) and cleared on `stop()`. It
+  // shares the app's injectable clock with `armTimer`, matching the cron
+  // gateway's fake-timer-friendly, skip-don't-queue discipline.
+  //
+  // Firing a timer marks `firedAt` through the (fenced, when leased) store, then
+  // resumes the run via the per-run locked path. The sleep executor recognizes
+  // its fired timer via the `firedTimers` set threaded into execution — the same
+  // seam as inbox/providerSessions — so the executor stays store-agnostic. We
+  // deliberately do NOT append a control inbound to wake the run: a sleeping run
+  // must rest with a fully-consumed inbox (`graphCursor === inbox.length`) so it
+  // is not misread as a crashed orphan, and an unconsumed control marker would
+  // break that terminal-boundary cursor contract.
+  // ---------------------------------------------------------------------------
+
+  private stopTimerSweep(): void {
+    this.timerSweepStopped = true;
+    if (this.timerSweepHandle !== undefined) {
+      clearTimeout(this.timerSweepHandle);
+      this.timerSweepHandle = undefined;
+    }
+  }
+
+  /** Fire all due timers, then re-arm the sweep for the next earliest wake-at. */
+  private async runTimerSweep(): Promise<void> {
+    if (this.timerSweepHandle !== undefined) {
+      clearTimeout(this.timerSweepHandle);
+      this.timerSweepHandle = undefined;
+    }
+    // Skip (do not queue) if a sweep is already running or the lease is lost —
+    // the in-flight sweep re-arms at the end, and a lost lease must not write.
+    if (this.timerSweepInFlight || this.timerSweepStopped || this.leaseLost) {
+      return;
+    }
+    this.timerSweepInFlight = true;
+    try {
+      const now = this.now();
+      const due: Array<{ runId: string; timerId: string }> = [];
+      for (const [runId, run] of await this.store.entries()) {
+        for (const timer of run.timers ?? []) {
+          if (timer.firedAt === undefined && timer.wakeAt <= now) {
+            due.push({ runId, timerId: timer.id });
+          }
+        }
+      }
+      for (const { runId, timerId } of due) {
+        try {
+          await this.fireTimer(runId, timerId);
+        } catch (error) {
+          this.onTimerError(runId, timerId, error);
+        }
+      }
+    } finally {
+      this.timerSweepInFlight = false;
+      await this.rearmTimerSweep();
+    }
+  }
+
+  /** Arm a single wake at the earliest pending (unfired) timer, if any. */
+  private async rearmTimerSweep(): Promise<void> {
+    if (this.timerSweepStopped || this.leaseLost) {
+      return;
+    }
+    if (this.timerSweepHandle !== undefined) {
+      clearTimeout(this.timerSweepHandle);
+      this.timerSweepHandle = undefined;
+    }
+    let earliest: number | undefined;
+    for (const [, run] of await this.store.entries()) {
+      for (const timer of run.timers ?? []) {
+        if (timer.firedAt === undefined) {
+          earliest =
+            earliest === undefined
+              ? timer.wakeAt
+              : Math.min(earliest, timer.wakeAt);
+        }
+      }
+    }
+    if (earliest === undefined || this.timerSweepStopped) {
+      return;
+    }
+    const delay = Math.max(0, earliest - this.now());
+    const handle = setTimeout(() => {
+      void this.runTimerSweep();
+    }, delay);
+    // Don't keep the process alive purely for the timer sweep.
+    handle.unref?.();
+    this.timerSweepHandle = handle;
+  }
+
+  /**
+   * Fire one due timer under its per-run mutex: mark `firedAt` through the
+   * (fenced) store, rebind the agent from the registry so it works after a cold
+   * restart, and resume the run. Re-checks under the lock so a concurrent fire
+   * or resume cannot double-fire; a timer already marked is a no-op.
+   */
+  private async fireTimer(runId: string, timerId: string): Promise<void> {
+    await this.runLocks.run(runId, async () => {
+      const run = await this.store.get(runId);
+      if (!run) {
+        return;
+      }
+      const timer = (run.timers ?? []).find(
+        (candidate) => candidate.id === timerId,
+      );
+      if (!timer || timer.firedAt !== undefined) {
+        return;
+      }
+      timer.firedAt = this.now();
+      await this.store.upsertTimer(runId, timer);
+      const agent = this.agents.get(run.agentName);
+      if (agent) {
+        run.agent = agent;
+      }
+      await this.resumeImpl(runId);
+    });
+  }
+
+  /**
+   * Arm (idempotently) a durable timer for a sleep node. Called by the executor
+   * via the `armTimer` seam while under the run's mutex. If a timer with this id
+   * is already armed (pending) its `wakeAt` is kept — re-executing the sleep
+   * node must not push the wake later. A timer already fired is left alone.
+   */
+  private async armTimer(
+    runId: string,
+    run: StoredRun<any>,
+    timerId: string,
+    durationMs: number,
+  ): Promise<void> {
+    const timers = (run.timers ??= []);
+    const existing = timers.find((candidate) => candidate.id === timerId);
+    if (existing) {
+      return;
+    }
+    const createdAt = this.now();
+    const timer: DurableTimer = {
+      id: timerId,
+      wakeAt: createdAt + durationMs,
+      kind: 'control',
+      createdAt,
+    };
+    timers.push(timer);
+    await this.store.upsertTimer(runId, timer);
+    // A newly-armed timer may be sooner than the current wake; re-arm the sweep.
+    await this.rearmTimerSweep();
   }
 
   async run<TVars extends Vars = Vars>(
@@ -1973,6 +2233,9 @@ export class PromptTrailApp {
           onInboxConsumed: (consumed) => {
             consumedInSlice = consumed;
           },
+          firedTimers: firedTimerIds(run),
+          armTimer: (timerId, durationMs) =>
+            this.armTimer(runId, run, timerId, durationMs),
           observers: [
             async (event) => {
               await this.emitObservers(run, event);
@@ -2205,6 +2468,17 @@ function normalizeInbound(
   input: string | Omit<Inbound, 'offset'>,
 ): Omit<Inbound, 'offset'> {
   return typeof input === 'string' ? { kind: 'user', content: input } : input;
+}
+
+/** Ids of the run's already-fired timers — the sleep executor's pass-through set. */
+function firedTimerIds(run: StoredRun<any>): ReadonlySet<string> {
+  const ids = new Set<string>();
+  for (const timer of run.timers ?? []) {
+    if (timer.firedAt !== undefined) {
+      ids.add(timer.id);
+    }
+  }
+  return ids;
 }
 
 function deliveryTargetFromContext(

--- a/packages/core/src/duration.ts
+++ b/packages/core/src/duration.ts
@@ -1,0 +1,65 @@
+/**
+ * Human-friendly duration parsing for durable timers (`Agent.sleep`).
+ *
+ * Supports a plain number of milliseconds or a compact string built from
+ * `<amount><unit>` segments, e.g. `'7d'`, `'2h30m'`, `'90s'`, `'1w'`, `'500ms'`.
+ * Whitespace between segments is allowed (`'1h 30m'`). The whole string must be
+ * consumed — an unrecognized unit or trailing garbage throws so a typo in an
+ * authored `sleep('7dd')` is a hard error rather than a silently-truncated wait.
+ *
+ * Intentionally dependency-free: durable timers live in core, and pulling a date
+ * library in for a one-file parser is not worth the surface area.
+ */
+
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+// Ordered longest-first so `ms` is matched before `m`.
+const SEGMENT_RE = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d|w)\s*/;
+
+/**
+ * Parse a duration into milliseconds.
+ *
+ * @throws if `input` is a negative/non-finite number, an empty string, or a
+ * string that is not fully consumed by `<amount><unit>` segments.
+ */
+export function parseDuration(input: number | string): number {
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input) || input < 0) {
+      throw new Error(
+        `Invalid duration ${input}: expected a non-negative, finite number of milliseconds.`,
+      );
+    }
+    return input;
+  }
+  const original = input;
+  let rest = input.trim();
+  if (rest === '') {
+    throw new Error('Invalid duration "": expected e.g. "7d", "2h30m", "90s".');
+  }
+  let total = 0;
+  let matchedAny = false;
+  while (rest.length > 0) {
+    const match = SEGMENT_RE.exec(rest);
+    if (!match) {
+      throw new Error(
+        `Invalid duration "${original}": expected e.g. "7d", "2h30m", "90s".`,
+      );
+    }
+    total += Number(match[1]) * UNIT_MS[match[2]];
+    rest = rest.slice(match[0].length);
+    matchedAny = true;
+  }
+  if (!matchedAny) {
+    throw new Error(
+      `Invalid duration "${original}": expected e.g. "7d", "2h30m", "90s".`,
+    );
+  }
+  return total;
+}

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -16,6 +16,7 @@ export type AgentGraphNodeType =
   | 'tools'
   | 'inbox'
   | 'awaitInput'
+  | 'sleep'
   | 'goal'
   | 'scope'
   | 'loop'
@@ -471,7 +472,7 @@ function isResumeSensitiveNode(
   node: AgentGraphNode,
   childWarningPaths: readonly string[],
 ): boolean {
-  if (node.type === 'awaitInput') {
+  if (node.type === 'awaitInput' || node.type === 'sleep') {
     return true;
   }
   if (node.type === 'goal' && graphDataInteraction(node.data) !== 'none') {

--- a/packages/core/src/graph_executor.ts
+++ b/packages/core/src/graph_executor.ts
@@ -26,6 +26,7 @@ import {
   type Message as PromptTrailMessage,
 } from './message';
 import { Session, type Vars } from './session';
+import { parseDuration } from './duration';
 import { type ModelOutput, Source } from './source';
 import { Parallel } from './templates/composite/parallel';
 import type { Template } from './templates/base';
@@ -81,6 +82,19 @@ export interface GraphExecutionOptions<TVars extends Vars = Vars> {
    * session the graph actually produced. See the checkpoint continuation model.
    */
   onInboxConsumed?: (consumedCount: number) => void;
+  /**
+   * Durable-timer wiring for `sleep` nodes (durability roadmap §3). Both are
+   * supplied by the checkpoint runtime; under ephemeral execution they are
+   * absent and `sleep` falls back to a real in-process wait.
+   *
+   * `firedTimers` holds the ids (sleep node graph paths) of timers the app has
+   * already fired — a sleep node whose id is present passes through instead of
+   * re-arming. `armTimer` persists (idempotently) a pending timer for the given
+   * node and duration; the runtime owns the clock so the executor stays
+   * store- and clock-agnostic.
+   */
+  firedTimers?: ReadonlySet<string>;
+  armTimer?: (timerId: string, durationMs: number) => Promise<void>;
 }
 
 export interface GraphToolDurableBoundaryContext<TVars extends Vars = Vars> {
@@ -139,6 +153,8 @@ interface GraphExecutionState<TVars extends Vars> {
   unsupportedCommandLabel?: string;
   activeGoal?: ActiveGoalExecution;
   onInboxConsumed?: (consumedCount: number) => void;
+  firedTimers?: ReadonlySet<string>;
+  armTimer?: (timerId: string, durationMs: number) => Promise<void>;
 }
 
 type GraphNodeData = Record<string, unknown>;
@@ -229,6 +245,8 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
     runEventSource: options.runEventSource ?? 'graph',
     unsupportedCommandLabel: options.unsupportedCommandLabel,
     onInboxConsumed: options.onInboxConsumed,
+    firedTimers: options.firedTimers,
+    armTimer: options.armTimer,
   };
 
   await emitGraphRunEvent('run.started', state, {
@@ -446,6 +464,9 @@ async function executeGraphNode<TVars extends Vars>(
           throw new GraphExecutionSuspended(nodePath, undefined, state.session);
         }
       }
+      return;
+    case 'sleep':
+      await executeSleepNode(node, nodePath, state);
       return;
     case 'structured':
       await executeStructuredNode(node, nodePath, state);
@@ -705,6 +726,74 @@ async function executeGoalAttemptsNode<TVars extends Vars>(
       }
     }
   }
+}
+
+/**
+ * A `sleep` node (durability roadmap §3).
+ *
+ * Durable path (checkpoint runtime supplies `armTimer`): on first execution the
+ * node arms a durable timer for `wakeAt = now + duration` and SUSPENDS at its
+ * coordinate — exactly like `awaitInput`, but woken by the app's timer sweep
+ * rather than an inbound. Arming is idempotent, so a resume that reaches an
+ * already-armed (still-pending) timer re-suspends WITHOUT resetting `wakeAt`.
+ * Once the app has fired the timer, the node's id is in `firedTimers` and the
+ * node passes through (it never re-arms — no infinite loop).
+ *
+ * Ephemeral path (no `armTimer`): a real in-process wait, cancellable via the
+ * abort signal. Nothing is persisted; the promise simply resolves after the
+ * duration.
+ */
+async function executeSleepNode<TVars extends Vars>(
+  node: AgentGraphNode,
+  nodePath: string,
+  state: GraphExecutionState<TVars>,
+): Promise<void> {
+  const durationMs = parseDuration(sleepDuration(node, nodePath));
+  if (state.armTimer) {
+    if (state.firedTimers?.has(nodePath)) {
+      return;
+    }
+    await state.armTimer(nodePath, durationMs);
+    throw new GraphExecutionSuspended(nodePath, undefined, state.session);
+  }
+  await waitMs(durationMs, state.signal);
+}
+
+function sleepDuration(
+  node: AgentGraphNode,
+  nodePath: string,
+): number | string {
+  const duration = graphNodeData(node).duration;
+  if (typeof duration === 'number' || typeof duration === 'string') {
+    return duration;
+  }
+  throw new Error(`Graph node ${nodePath} requires a sleep duration.`);
+}
+
+function waitMs(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortReason(signal));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function abortReason(signal?: AbortSignal): Error {
+  const reason = signal?.reason;
+  return reason instanceof Error ? reason : new Error('Sleep aborted.');
 }
 
 async function executeUserNode<TVars extends Vars>(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   CheckpointOption,
   DurableRunResult,
   DurableRunStore,
+  DurableTimer,
   Inbound,
   InboundKind,
   InboundRuntimeEvent,
@@ -60,6 +61,7 @@ export type {
   StoredRun,
   StoredRunPatch,
 } from './durable';
+export { parseDuration } from './duration';
 export { DELETE_VALUE, Observer } from './execution';
 export type {
   AuthoredSessionPatch,

--- a/packages/core/src/templates/agent.ts
+++ b/packages/core/src/templates/agent.ts
@@ -510,6 +510,31 @@ export class Agent<TC extends Vars = Vars> {
     return this;
   }
 
+  /**
+   * Durable sleep (durability roadmap §3). Suspends the run for `duration` and
+   * resumes past the node once the app's timer sweep fires — the wake-at is
+   * persisted, so the sleep survives restarts. `duration` is milliseconds or a
+   * human string like `'2h'` / `'7d'` / `'1h30m'`. Under ephemeral (non
+   * checkpoint) execution it is a real in-process wait.
+   */
+  sleep(duration: number | string): this;
+  sleep(id: string, duration: number | string): this;
+  sleep(idOrDuration: string | number, maybeDuration?: number | string): this {
+    if (maybeDuration !== undefined) {
+      this.graphNodes.push({
+        id: idOrDuration as string,
+        type: 'sleep',
+        data: { duration: maybeDuration },
+      });
+      return this;
+    }
+    this.graphNodes.push({
+      type: 'sleep',
+      data: { duration: idOrDuration },
+    });
+    return this;
+  }
+
   transform(transform: AgentGraphPureTransformHandler<TC>): this;
   transform(
     options: AgentGraphTransformEffectOptions,
@@ -1751,6 +1776,8 @@ function graphNodeTemplateName(node: AgentGraphNodeDraft): string {
       return 'Inbox';
     case 'awaitInput':
       return 'AwaitInput';
+    case 'sleep':
+      return 'Sleep';
     case 'goal':
       return 'Goal';
     default:

--- a/packages/cron/src/index.ts
+++ b/packages/cron/src/index.ts
@@ -81,6 +81,20 @@ const CRON_TRIGGER_TYPE = 'cron.schedule';
  * Overlap policy: fires are NOT queued. If a job's previous emit is still
  * awaiting when its next fire is due, that fire is skipped; the following
  * occurrence is still armed.
+ *
+ * Relationship to durable timers (roadmap §3 — "timers should unify with the
+ * cron trigger plumbing rather than grow a second scheduler"): the unification
+ * is the shared SCHEDULING DISCIPLINE, not a merged code path. Both this gateway
+ * and the core durable-timer sweep (`PromptTrailApp`, packages/core/src/durable.ts)
+ * follow the same rules — an injectable clock, self-driven `setTimeout`s that
+ * compute the next fire and re-arm after each occurrence, skip-don't-queue
+ * re-entrancy, and cleanup on stop — so neither grows into a second ad-hoc
+ * scheduler. They stay separate deliberately: cron is a stateless wall-clock
+ * TRIGGER that starts runs, while durable timers are per-run WAKE-UPS whose
+ * wake-at is persisted and re-armed on boot. The intended future convergence is
+ * a cron occurrence that arms a durable timer (a scheduled run that survives a
+ * restart between fire and delivery); that reuse lives on top of this same
+ * discipline, not by moving the durable-timer sweep into this package.
  */
 export function cronGateway(options: CronGatewayOptions = {}): RuntimeAdapter {
   let scheduler: CronScheduler | undefined;

--- a/packages/store-common/src/index.ts
+++ b/packages/store-common/src/index.ts
@@ -2,6 +2,7 @@ import {
   Session,
   type Agent,
   type AssistantDeliveryOutboxEntry,
+  type DurableTimer,
   type Inbound,
   type Message,
   type OnceScope,
@@ -113,6 +114,8 @@ export interface ReconstructStoredRunInput {
   inbox: Inbound[];
   outbox: AssistantDeliveryOutboxEntry[];
   providerSessions: Record<string, ProviderSessionBinding>;
+  /** Parsed durable timers, if the backend stores any. */
+  timers?: DurableTimer[];
 }
 
 /**
@@ -165,6 +168,10 @@ export function reconstructStoredRun(
   }
 
   run.providerSessions = { ...input.providerSessions };
+
+  if (input.timers && input.timers.length > 0) {
+    run.timers = input.timers.map((timer) => ({ ...timer }));
+  }
 
   return run;
 }

--- a/packages/store-conformance/src/index.ts
+++ b/packages/store-conformance/src/index.ts
@@ -8,6 +8,7 @@ import {
   type SessionCheckpointDelta,
   type Inbound,
   type AssistantDeliveryOutboxEntry,
+  type DurableTimer,
 } from '@prompttrail/core';
 
 /**
@@ -853,6 +854,113 @@ export function runDurableRunStoreConformance(spec: ConformanceSpec): void {
       // The persisted counter survives the reopen: the new token is strictly
       // greater than the pre-reopen token, never reset to zero.
       expect(s2!.token).toBeGreaterThan(s1!.token);
+    });
+
+    // -----------------------------------------------------------------------
+    // Durable timer cases (durability roadmap §3)
+    // -----------------------------------------------------------------------
+
+    // Case 23: upsertTimer round-trips and is idempotent by (runId, id) — a
+    // second upsert with the same id REPLACES the row (e.g. marking firedAt),
+    // it does not append a duplicate. A second id makes a second timer.
+    it('case 23: upsertTimer round-trip + idempotent upsert', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-timer-23';
+      await store.create(runId, makeInitialRun(agent, agentName));
+
+      const timer: DurableTimer = {
+        id: 'sleeper/wait',
+        wakeAt: BASE_NOW + 60_000,
+        kind: 'control',
+        createdAt: BASE_NOW,
+      };
+      await store.upsertTimer(runId, timer);
+
+      let retrieved = await store.get(runId);
+      expect(retrieved!.timers).toHaveLength(1);
+      expect(retrieved!.timers![0].id).toBe('sleeper/wait');
+      expect(retrieved!.timers![0].wakeAt).toBe(BASE_NOW + 60_000);
+      expect(retrieved!.timers![0].firedAt).toBeUndefined();
+
+      // Same id => replace, not duplicate (mark it fired).
+      await store.upsertTimer(runId, { ...timer, firedAt: BASE_NOW + 60_000 });
+      retrieved = await store.get(runId);
+      expect(retrieved!.timers).toHaveLength(1);
+      expect(retrieved!.timers![0].firedAt).toBe(BASE_NOW + 60_000);
+
+      // Different id => new timer.
+      await store.upsertTimer(runId, {
+        id: 'sleeper/wait2',
+        wakeAt: BASE_NOW + 120_000,
+        createdAt: BASE_NOW,
+      });
+      retrieved = await store.get(runId);
+      expect(retrieved!.timers).toHaveLength(2);
+    });
+
+    // Case 24: DURABILITY — timers survive a store reopen. Skipped for in-memory
+    // stores with no reopen, like case 12.
+    it('case 24: durable timers survive reopen', async () => {
+      await openStore();
+      if (!reopen) {
+        return;
+      }
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-timer-24';
+      await store.create(runId, makeInitialRun(agent, agentName));
+
+      await store.upsertTimer(runId, {
+        id: 'sleeper/pending',
+        wakeAt: BASE_NOW + 3_600_000,
+        payload: 'timer:sleeper/pending',
+        kind: 'control',
+        createdAt: BASE_NOW,
+      });
+      await store.upsertTimer(runId, {
+        id: 'sleeper/fired',
+        wakeAt: BASE_NOW + 1_000,
+        createdAt: BASE_NOW,
+        firedAt: BASE_NOW + 1_500,
+      });
+
+      const fresh = await reopen();
+      const reconstructed = await fresh.get(runId);
+      const timers = [...(reconstructed!.timers ?? [])].sort((a, b) =>
+        a.id.localeCompare(b.id),
+      );
+      expect(timers).toHaveLength(2);
+      const fired = timers.find((t) => t.id === 'sleeper/fired')!;
+      const pending = timers.find((t) => t.id === 'sleeper/pending')!;
+      expect(fired.firedAt).toBe(BASE_NOW + 1_500);
+      expect(pending.firedAt).toBeUndefined();
+      expect(pending.wakeAt).toBe(BASE_NOW + 3_600_000);
+      expect(pending.payload).toBe('timer:sleeper/pending');
+      expect(pending.kind).toBe('control');
+    });
+
+    // Case 25: delete cascades timers — a recreated runId must not fold the old
+    // incarnation's timer rows into the new run.
+    it('case 25: delete cascades timers', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-timer-25';
+      await store.create(runId, makeInitialRun(agent, agentName));
+      await store.upsertTimer(runId, {
+        id: 'sleeper/leaked',
+        wakeAt: BASE_NOW + 5_000,
+        createdAt: BASE_NOW,
+      });
+
+      await store.delete(runId);
+      expect(await store.has(runId)).toBe(false);
+
+      await store.create(runId, makeInitialRun(agent, agentName));
+      const reconstructed = await store.get(runId);
+      expect(reconstructed!.timers ?? []).toHaveLength(0);
     });
   });
 }

--- a/packages/store-libsql/src/index.ts
+++ b/packages/store-libsql/src/index.ts
@@ -4,7 +4,9 @@ import {
   type Agent,
   type AssistantDeliveryOutboxEntry,
   type DurableRunStore,
+  type DurableTimer,
   type Inbound,
+  type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
   type RunStoreLease,
@@ -459,6 +461,34 @@ export class LibsqlRunStore implements DurableRunStore {
     });
   }
 
+  async upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    await this.client.execute({
+      sql: `INSERT INTO timers (run_id, id, wake_at, payload, kind, created_at, fired_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(run_id, id)
+            DO UPDATE SET
+              wake_at = excluded.wake_at,
+              payload = excluded.payload,
+              kind = excluded.kind,
+              created_at = excluded.created_at,
+              fired_at = excluded.fired_at`,
+      args: [
+        runId,
+        timer.id,
+        timer.wakeAt,
+        timer.payload ?? null,
+        timer.kind ?? null,
+        timer.createdAt,
+        timer.firedAt ?? null,
+      ],
+    });
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     // Deleting the parent runs row is sufficient: the schema declares
@@ -543,6 +573,18 @@ export class LibsqlRunStore implements DurableRunStore {
         node_path TEXT NOT NULL,
         binding_json TEXT NOT NULL,
         PRIMARY KEY (run_id, node_path),
+        FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS timers (
+        run_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        wake_at INTEGER NOT NULL,
+        payload TEXT,
+        kind TEXT,
+        created_at INTEGER NOT NULL,
+        fired_at INTEGER,
+        PRIMARY KEY (run_id, id),
         FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
       );
 
@@ -651,7 +693,31 @@ export class LibsqlRunStore implements DurableRunStore {
       ) as ProviderSessionBinding;
     }
 
-    // 7. Delegate assembly to the shared reconstruction helper.
+    // 7. Gather durable timers ordered by id.
+    const timerRes = await this.client.execute({
+      sql: `SELECT id, wake_at, payload, kind, created_at, fired_at
+            FROM timers WHERE run_id = ? ORDER BY id ASC`,
+      args: [runId],
+    });
+    const timers: DurableTimer[] = timerRes.rows.map((trow) => {
+      const timer: DurableTimer = {
+        id: trow[0] as string,
+        wakeAt: trow[1] as number,
+        createdAt: trow[4] as number,
+      };
+      if (trow[2] !== null) {
+        timer.payload = trow[2] as string;
+      }
+      if (trow[3] !== null) {
+        timer.kind = trow[3] as InboundKind;
+      }
+      if (trow[5] !== null) {
+        timer.firedAt = trow[5] as number;
+      }
+      return timer;
+    });
+
+    // 8. Delegate assembly to the shared reconstruction helper.
     return reconstructStoredRun(
       {
         agentName: row.agent_name,
@@ -666,6 +732,7 @@ export class LibsqlRunStore implements DurableRunStore {
         inbox,
         outbox,
         providerSessions,
+        timers,
       },
       this.agents,
     );

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -4,7 +4,9 @@ import {
   type Agent,
   type AssistantDeliveryOutboxEntry,
   type DurableRunStore,
+  type DurableTimer,
   type Inbound,
+  type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
   type RunStoreLease,
@@ -559,6 +561,39 @@ export class PostgresRunStore implements DurableRunStore {
     }
   }
 
+  async upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const client = await this.pool.connect();
+    try {
+      await client.query(
+        `INSERT INTO timers (run_id, id, wake_at, payload, kind, created_at, fired_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (run_id, id)
+         DO UPDATE SET
+           wake_at = EXCLUDED.wake_at,
+           payload = EXCLUDED.payload,
+           kind = EXCLUDED.kind,
+           created_at = EXCLUDED.created_at,
+           fired_at = EXCLUDED.fired_at`,
+        [
+          runId,
+          timer.id,
+          timer.wakeAt,
+          timer.payload ?? null,
+          timer.kind ?? null,
+          timer.createdAt,
+          timer.firedAt ?? null,
+        ],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     // Delete the run AND all of its child rows in a single transaction.
@@ -581,6 +616,7 @@ export class PostgresRunStore implements DurableRunStore {
       await client.query('DELETE FROM provider_sessions WHERE run_id = $1', [
         runId,
       ]);
+      await client.query('DELETE FROM timers WHERE run_id = $1', [runId]);
       await client.query('DELETE FROM runs WHERE run_id = $1', [runId]);
       await client.query('COMMIT');
     } catch (error) {
@@ -663,6 +699,16 @@ export class PostgresRunStore implements DurableRunStore {
           node_path TEXT NOT NULL,
           binding_json TEXT NOT NULL,
           PRIMARY KEY (run_id, node_path)
+        )`,
+        timers: `CREATE TABLE timers (
+          run_id TEXT NOT NULL,
+          id TEXT NOT NULL,
+          wake_at BIGINT NOT NULL,
+          payload TEXT,
+          kind TEXT,
+          created_at BIGINT NOT NULL,
+          fired_at BIGINT,
+          PRIMARY KEY (run_id, id)
         )`,
         lease: `CREATE TABLE lease (
           id INTEGER PRIMARY KEY,
@@ -806,7 +852,41 @@ export class PostgresRunStore implements DurableRunStore {
       ) as ProviderSessionBinding;
     }
 
-    // 7. Delegate assembly to the shared reconstruction helper.
+    // 7. Gather durable timers. BIGINT columns come back as strings from pg, so
+    // coerce the epoch-ms fields with Number().
+    const timerRes = await client.query(
+      `SELECT id, wake_at, payload, kind, created_at, fired_at
+       FROM timers WHERE run_id = $1 ORDER BY id ASC`,
+      [runId],
+    );
+    const timers: DurableTimer[] = (
+      timerRes.rows as {
+        id: string;
+        wake_at: number | string;
+        payload: string | null;
+        kind: InboundKind | null;
+        created_at: number | string;
+        fired_at: number | string | null;
+      }[]
+    ).map((trow) => {
+      const timer: DurableTimer = {
+        id: trow.id,
+        wakeAt: Number(trow.wake_at),
+        createdAt: Number(trow.created_at),
+      };
+      if (trow.payload !== null) {
+        timer.payload = trow.payload;
+      }
+      if (trow.kind !== null) {
+        timer.kind = trow.kind;
+      }
+      if (trow.fired_at !== null) {
+        timer.firedAt = Number(trow.fired_at);
+      }
+      return timer;
+    });
+
+    // 8. Delegate assembly to the shared reconstruction helper.
     return reconstructStoredRun(
       {
         agentName: row.agent_name,
@@ -821,6 +901,7 @@ export class PostgresRunStore implements DurableRunStore {
         inbox,
         outbox,
         providerSessions,
+        timers,
       },
       this.agents,
     );

--- a/packages/store-redis/src/index.ts
+++ b/packages/store-redis/src/index.ts
@@ -4,6 +4,7 @@ import type {
   Agent,
   AssistantDeliveryOutboxEntry,
   DurableRunStore,
+  DurableTimer,
   Inbound,
   OnceScope,
   ProviderSessionBinding,
@@ -50,6 +51,8 @@ interface RunDocument {
   outbox: AssistantDeliveryOutboxEntry[];
   /** Provider session bindings keyed by nodePath. */
   providerSessions: Record<string, ProviderSessionBinding>;
+  /** Durable timers, upserted by id. Optional so old docs stay readable. */
+  timers?: DurableTimer[];
 }
 
 interface SerializedDelta {
@@ -360,6 +363,7 @@ export class RedisRunStore implements DurableRunStore {
       inbox: [],
       outbox: [],
       providerSessions: {},
+      timers: [],
     };
     await this.saveDoc(runId, doc);
     await this.client.sadd(this.indexKey(), runId);
@@ -501,6 +505,26 @@ export class RedisRunStore implements DurableRunStore {
     await this.saveDoc(runId, doc);
   }
 
+  async upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const doc = await this.loadDoc(runId);
+    if (!doc) {
+      return;
+    }
+    const timers = (doc.timers ??= []);
+    const idx = timers.findIndex((t) => t.id === timer.id);
+    if (idx === -1) {
+      timers.push(timer);
+    } else {
+      timers[idx] = timer;
+    }
+    await this.saveDoc(runId, doc);
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     await this.client.del(this.runKey(runId));
@@ -555,6 +579,7 @@ export class RedisRunStore implements DurableRunStore {
         inbox: doc.inbox,
         outbox: doc.outbox,
         providerSessions: doc.providerSessions,
+        timers: doc.timers ?? [],
       },
       this.agents,
     );

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -7,7 +7,9 @@ import {
   type Agent,
   type AssistantDeliveryOutboxEntry,
   type DurableRunStore,
+  type DurableTimer,
   type Inbound,
+  type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
   type RunStoreLease,
@@ -185,6 +187,7 @@ export interface SqliteWriteJournalEntry {
     | 'recordOnce'
     | 'upsertOutbox'
     | 'recordProviderSession'
+    | 'upsertTimer'
     | 'patch'
     | 'delete';
   summary: string;
@@ -247,6 +250,16 @@ interface ProviderSessionRow {
   binding_json: string;
 }
 
+interface TimerRow {
+  run_id: string;
+  id: string;
+  wake_at: number;
+  payload: string | null;
+  kind: InboundKind | null;
+  created_at: number;
+  fired_at: number | null;
+}
+
 /**
  * SQLite restart substrate for PromptTrail durable runs.
  *
@@ -274,6 +287,7 @@ export class SqliteRunStore implements DurableRunStore {
   private readonly insertInboxStmt: Database.Statement;
   private readonly upsertOutboxStmt: Database.Statement;
   private readonly upsertProviderSessionStmt: Database.Statement;
+  private readonly upsertTimerStmt: Database.Statement;
 
   constructor(options: SqliteRunStoreOptions) {
     const dbPath = options.path ?? join(cwd(), '.data', 'prompttrail.db');
@@ -347,6 +361,18 @@ export class SqliteRunStore implements DurableRunStore {
       VALUES (?, ?, ?)
       ON CONFLICT(run_id, node_path)
       DO UPDATE SET binding_json = excluded.binding_json
+    `);
+
+    this.upsertTimerStmt = this.db.prepare(`
+      INSERT INTO timers (run_id, id, wake_at, payload, kind, created_at, fired_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(run_id, id)
+      DO UPDATE SET
+        wake_at = excluded.wake_at,
+        payload = excluded.payload,
+        kind = excluded.kind,
+        created_at = excluded.created_at,
+        fired_at = excluded.fired_at
     `);
 
     this.sqliteLease = new SqliteLease(this.db, options.now ?? Date.now);
@@ -554,6 +580,41 @@ export class SqliteRunStore implements DurableRunStore {
     );
   }
 
+  async upsertTimer(
+    runId: string,
+    timer: DurableTimer,
+    fence?: number,
+  ): Promise<void> {
+    this.assertFence(fence);
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    this.upsertTimerStmt.run(
+      runId,
+      timer.id,
+      timer.wakeAt,
+      timer.payload ?? null,
+      timer.kind ?? null,
+      timer.createdAt,
+      timer.firedAt ?? null,
+    );
+    const timers = (run.timers ??= []);
+    const index = timers.findIndex((candidate) => candidate.id === timer.id);
+    if (index >= 0) {
+      timers[index] = timer;
+    } else {
+      timers.push(timer);
+    }
+    this.recordJournal(
+      runId,
+      'upsertTimer',
+      `UPSERT timers (${quoteOneLine(timer.id)}, wake_at=${timer.wakeAt}${
+        timer.firedAt !== undefined ? ', fired' : ''
+      })`,
+    );
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     this.assertFence(fence);
     this.deleteRunStmt.run(runId);
@@ -640,6 +701,18 @@ export class SqliteRunStore implements DurableRunStore {
         FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
       );
 
+      CREATE TABLE IF NOT EXISTS timers (
+        run_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        wake_at INTEGER NOT NULL,
+        payload TEXT,
+        kind TEXT,
+        created_at INTEGER NOT NULL,
+        fired_at INTEGER,
+        PRIMARY KEY (run_id, id),
+        FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+      );
+
       CREATE TABLE IF NOT EXISTS lease (
         id INTEGER PRIMARY KEY CHECK (id = 1),
         holder TEXT NOT NULL,
@@ -669,6 +742,9 @@ export class SqliteRunStore implements DurableRunStore {
     const providerRows = this.db
       .prepare('SELECT * FROM provider_sessions ORDER BY run_id, node_path')
       .all() as ProviderSessionRow[];
+    const timerRows = this.db
+      .prepare('SELECT * FROM timers ORDER BY run_id, id')
+      .all() as TimerRow[];
 
     // Group child rows per run_id, preserving the SELECT ordering so each
     // run's components (deltas in seq order, inbox in offset order, etc.) are
@@ -678,6 +754,7 @@ export class SqliteRunStore implements DurableRunStore {
     const inboxByRun = groupBy(inboxRows, (row) => row.run_id);
     const outboxByRun = groupBy(outboxRows, (row) => row.run_id);
     const providerByRun = groupBy(providerRows, (row) => row.run_id);
+    const timersByRun = groupBy(timerRows, (row) => row.run_id);
 
     for (const row of runRows) {
       const deltas: SessionCheckpointDelta<any>[] = (
@@ -723,6 +800,10 @@ export class SqliteRunStore implements DurableRunStore {
         ) as ProviderSessionBinding;
       }
 
+      const timers: DurableTimer[] = (timersByRun.get(row.run_id) ?? []).map(
+        (trow) => timerFromRow(trow),
+      );
+
       const run = reconstructStoredRun(
         {
           agentName: row.agent_name,
@@ -737,6 +818,7 @@ export class SqliteRunStore implements DurableRunStore {
           inbox,
           outbox,
           providerSessions,
+          timers,
         },
         agents,
       );
@@ -771,6 +853,24 @@ export class SqliteRunStore implements DurableRunStore {
     }
     this.writeJournal.set(runId, entries);
   }
+}
+
+function timerFromRow(row: TimerRow): DurableTimer {
+  const timer: DurableTimer = {
+    id: row.id,
+    wakeAt: row.wake_at,
+    createdAt: row.created_at,
+  };
+  if (row.payload !== null) {
+    timer.payload = row.payload;
+  }
+  if (row.kind !== null) {
+    timer.kind = row.kind;
+  }
+  if (row.fired_at !== null) {
+    timer.firedAt = row.fired_at;
+  }
+  return timer;
 }
 
 function groupBy<T>(


### PR DESCRIPTION
sleep('7d') that survives restarts:

- `.sleep(id, duration)` node: durable path persists {id=node path, wakeAt} (idempotent re-arm) and suspends; ephemeral path is a plain await
- App timer service: one self-driven sweep armed at the earliest pending wakeAt (unref'd, cleared on stop, skip-don't-queue, injectable clock — same discipline as cronGateway; unification note added there); boot sweep fires past-due timers after lease acquisition and recovery
- Firing marks firedAt (fenced write under lease mode) and resumes via the locked path; the fired-timer set threads into the executor like the inbox does, keeping it store/clock-agnostic. No control inbound is appended — a sleeping run must not look like an orphan to the recovery scan
- upsertTimer on all five backends + conformance cases 23–25 (round-trip/idempotency, reopen survival, delete cascade); parseDuration with tests; README subsection + typechecked snippet

core 757 unit (+9), stores 50/25/25/25, claw 23, discord 16, cron 10, build/typecheck/prettier green.