### PR TITLE
feat: claw Phase 2 — supervision, trust tiers, audit, rollback

### DIFF
--- a/claw/README.md
+++ b/claw/README.md
@@ -231,3 +231,123 @@ restart reload (fresh registry + skills dir → skill still dispatches); the
 parent manifest hash staying unchanged after authoring; and authoring firing
 only in the privileged channel/author allowlist. The subprocess-backed tests
 locate `tsc`/`vitest` from the workspace `node_modules`.
+
+## Skills (Phase 2): supervision & lifecycle
+
+**Phase 2** adds the **control plane** beside the data plane (the dispatcher):
+trust tiers, automatic promotion/quarantine, an on-demand supervisor command
+surface, rollback via an active-version pointer, and a full provenance/audit
+trail. The governing rule from `design-docs/claw-self-authoring.md` §9 holds:
+**instrument every skill run, but never proxy them through a blocking
+supervisor.** The supervisor is human-authored, trusted, in-repo code _outside_
+the self-authoring loop; nothing here recompiles the parent graph.
+
+### Trust tiers
+
+```
+builtin        hand-written, trusted (status, author-skill, supervisor)
+staged         gate-passed, not yet activated (transient — authoring moves on immediately)
+  │  activate
+  ▼
+canary         LIVE and dispatching, but closely watched + read-only ceiling
+  │  auto: N clean invocations (CLAW_PROMOTE_AFTER)
+  ▼
+trusted        auto-promoted; still read-only in Phase 2 (write elevation deferred)
+  ↘  auto: K consecutive failures (CLAW_QUARANTINE_AFTER), or !quarantine
+quarantined    dispatcher SKIPS it (like disabled); !restore → canary
+```
+
+**Canary is live.** Phase 1's "activated" state is exactly canary: a
+gate-passed skill dispatches immediately, but is flagged for close watching and
+capped at the read-only ceiling. The authoring flow now records the
+`staged → canary` transition explicitly (both steps audited); the persisted tier
+is the terminal `canary`.
+
+- **Auto-promotion** (`canary → trusted`) and **auto-quarantine**
+  (`* → quarantined`) are evaluated in the **health wrapper** after each
+  invocation — cheap, data-plane, off the blocking path. Both are registry
+  writes. Builtin skills are never touched.
+- **Rollback = an active-version pointer.** Every gated build keeps an immutable
+  per-version artifact under `<skillsDir>/versions/<id>.<hash>.js`. `!rollback`
+  repoints `activeVersion` to the previous version row and rebinds the in-process
+  behavior — instant, and (because the skill subroutine hash is excluded from the
+  parent manifest, §8) it disturbs neither the parent graph nor live
+  conversations.
+
+### Supervisor commands
+
+A built-in, trusted `supervisor` skill (registered only when
+`CLAW_AUTHORING_CHANNELS` is set, sharing the same privileged channel/author
+gating as `!skill`). All are read-only w.r.t. capabilities:
+
+| Command            | Effect                                                                       |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `!skills`          | List every skill: id, name, tier, enabled, invocations, failures, hash short |
+| `!promote <id>`    | One step: `staged → canary`, or `canary → trusted` (trust tier **only**)     |
+| `!quarantine <id>` | Force `→ quarantined`; the dispatcher stops matching it                       |
+| `!restore <id>`    | `quarantined → canary`, resetting the consecutive-failure streak             |
+| `!rollback <id>`   | Move the active-version pointer to the previous version; error if none       |
+| `!why <id>`        | Last error/latency, failure counts, gate summary, recent audit entries       |
+
+`!skills` and `!why` also drain any buffered supervisor notices (below).
+
+### Provenance / audit surface
+
+Every tier transition appends a row to `skill_audit`
+(`skillId, from, to, reason, actor, at`); `actor` is `auto` for supervisor logic
+or the author/supervisor id for a command. `!why` shows the most recent entries;
+`!skills` and `!why` expose the live health + version state. This is the
+auditable trail of every promote/demote/rollback the design calls for.
+
+### Supervisor invocation modes (§9)
+
+- **On-demand** — the commands above.
+- **Scheduled** — set `CLAW_SUPERVISOR_CRON` (a cron expression) to wire a cron
+  binding (via `@prompttrail/cron`'s `cron.schedule` + `cronGateway`) that runs
+  the quarantine scan, catching skills that crossed the failure threshold **while
+  idle** (the reactive path only fires on invocation).
+- **Reactive** — when the health wrapper trips the quarantine threshold it
+  **buffers a pending notice** rather than posting to a channel directly.
+  Delivering a message to `CLAW_SUPERVISOR_CHANNEL` from inside the wrapper is
+  awkward in claw's message-triggered binding model — the wrapper runs while
+  replying to the _triggering_ message and has no handle to a different channel —
+  so the notice is written to a durable `skill_notices` row and surfaced by the
+  next `!skills`/`!why` command or scheduled scan (then marked delivered). This
+  keeps the supervisor strictly off the hot path.
+
+### Env vars
+
+| Var                     | Default | Meaning                                       |
+| ----------------------- | ------- | --------------------------------------------- |
+| `CLAW_PROMOTE_AFTER`    | `20`    | Clean invocations before `canary → trusted`   |
+| `CLAW_QUARANTINE_AFTER` | `3`     | Consecutive failures before `→ quarantined`   |
+| `CLAW_SUPERVISOR_CHANNEL` | (unset) | Channel a reactive notice is intended for     |
+| `CLAW_SUPERVISOR_CRON`  | (unset) | Cron expr for the scheduled quarantine scan   |
+
+### Capability elevation is deferred
+
+Phase 2 does **not** grant write capability. The verification gate still rejects
+any external-write effect (`idempotencyKey`) and any tool registration, so the
+read-only ceiling holds for **every** self-authored skill at **every** tier.
+`!promote` raises the _trust_ tier (how closely a skill is watched), never the
+_capability_ ceiling. Write elevation with an explicit human-confirmation step
+(§6/§9) is left to a later pass.
+
+### Deferred to later passes
+
+- **Capability elevation** (self-authored write effects) — see above.
+- **Curator** — the scoring/merging/pruning pass over the skill library (§10) is
+  explicitly a later pass and is not implemented here.
+- **Git as audit archive** (§9 open question) — one commit per gated version for
+  human-reviewable diffs. Live tier/health/pointer state stays in the durable
+  store; the git export is out of scope for now.
+
+### Tests (Phase 2)
+
+`supervisor.test.ts` covers: the tier lifecycle (`staged → canary` on activate,
+`canary → trusted` after N clean runs, auto-quarantine after K failures, the
+dispatcher skipping a quarantined skill, `!restore` resetting the failure
+streak); rollback moving the pointer so the _previous_ version's behavior
+dispatches again (author v1, author v2 same id, `!rollback` → v1 replies);
+supervisor command channel/author gating; audit rows written on every
+transition; and the scheduled scan quarantining a skill that failed while idle.

--- a/claw/package.json
+++ b/claw/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@prompttrail/core": "workspace:*",
+    "@prompttrail/cron": "workspace:*",
     "@prompttrail/discord": "workspace:*",
     "@prompttrail/store-sqlite": "workspace:*",
     "better-sqlite3": "^12.10.0",

--- a/claw/src/index.ts
+++ b/claw/src/index.ts
@@ -2,15 +2,18 @@ import 'dotenv/config';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Agent, PromptTrail, Source } from '@prompttrail/core';
+import { cron, cronGateway } from '@prompttrail/cron';
 import { discord, discordGateway } from '@prompttrail/discord';
 import { SqliteRunStore } from '@prompttrail/store-sqlite';
 import {
   createAuthorSkill,
   createClawSkillAgent,
   createStatusSkill,
+  createSupervisorSkill,
   findClawRoot,
   llmSynthesizer,
   loadStagedSkills,
+  quarantineScan,
   registerBuiltinSkills,
   skillToRow,
   SkillRegistry,
@@ -20,6 +23,7 @@ import {
   type SkillLoaderContext,
   type SkillReplySource,
   type SkillSynthesizer,
+  type SupervisionConfig,
 } from './skills/index.js';
 
 interface ClawConfig {
@@ -80,9 +84,19 @@ const loaderContext: SkillLoaderContext = {
 // source through the same gate-import path (full re-gate only if source changed).
 await loadStagedSkills(loaderContext);
 
+// Phase 2 supervision thresholds (design-docs/claw-self-authoring.md §9-§10).
+// The health wrapper auto-promotes a clean canary and auto-quarantines a skill
+// past the failure threshold; both are registry writes off the hot path.
+const supervisionConfig: SupervisionConfig = {
+  promoteAfter: readInteger('CLAW_PROMOTE_AFTER', 20),
+  quarantineAfter: readInteger('CLAW_QUARANTINE_AFTER', 3),
+  supervisorChannel: readOptionalString('CLAW_SUPERVISOR_CHANNEL'),
+};
+
 // Register the trusted authoring entry point ONLY when a privileged channel is
 // configured (§6 authorization boundary). Without CLAW_AUTHORING_CHANNELS, `!skill`
-// does nothing — a normal message can invoke skills but never author them.
+// does nothing — a normal message can invoke skills but never author them. The
+// supervisor commands share the same privileged channel/author gating.
 const authoringChannels = readList('CLAW_AUTHORING_CHANNELS', []);
 const authors = readList('CLAW_AUTHORS', []);
 if (authoringChannels.length > 0) {
@@ -92,14 +106,21 @@ if (authoringChannels.length > 0) {
     authoringChannels,
     authors,
   });
-  skills.set(authorSkill.id, authorSkill);
-  const authorRow = skillToRow(authorSkill);
-  const existing = registry.get(authorSkill.id);
-  if (existing) {
-    // Keep channel narrowing current with the env; respect a manual disable.
-    authorRow.enabled = existing.enabled;
+  const supervisorSkill = createSupervisorSkill({
+    loaderContext,
+    supervisorChannels: authoringChannels,
+    authors,
+  });
+  for (const builtin of [supervisorSkill, authorSkill]) {
+    skills.set(builtin.id, builtin);
+    const row = skillToRow(builtin);
+    const existing = registry.get(builtin.id);
+    if (existing) {
+      // Keep channel narrowing current with the env; respect a manual disable.
+      row.enabled = existing.enabled;
+    }
+    registry.upsert(row);
   }
-  registry.upsert(authorRow);
 }
 
 validateSkillRegistry(registry, skills);
@@ -109,10 +130,29 @@ const mainAgent = createClawSkillAgent({
   registry,
   skills,
   defaultReply: buildDefaultReply(config),
+  supervision: supervisionConfig,
 });
 
+// Optional scheduled supervisor: a cron scan that quarantines skills already
+// over the failure threshold (catches skills that failed while idle). Wired only
+// when CLAW_SUPERVISOR_CRON is set (design-docs §9 scheduled mode).
+const supervisorCron = readOptionalString('CLAW_SUPERVISOR_CRON');
+const scanAgent = Agent.create('supervisor-scan')
+  .inbox('inbound')
+  .transform('scan', { effect: { repeatable: true } }, (session) => {
+    const quarantined = quarantineScan(registry, supervisionConfig);
+    const summary =
+      quarantined.length > 0
+        ? `supervisor scan: quarantined ${quarantined.join(', ')}`
+        : 'supervisor scan: no skills over threshold';
+    console.log(summary);
+    return session.addMessage({ type: 'assistant', content: summary });
+  });
+
 const store = new SqliteRunStore({
-  agents: { main: mainAgent },
+  agents: supervisorCron
+    ? { main: mainAgent, 'supervisor-scan': scanAgent }
+    : { main: mainAgent },
   path: clawDbPath,
 });
 
@@ -122,30 +162,43 @@ const runtime = PromptTrail.app({
   defaults: {
     checkpoint: true,
   },
-})
-  .agent('main', mainAgent)
-  .on(discord.messages(), (binding) =>
-    binding
-      .where(discord.notBot())
-      .toAgent('main')
-      .conversation(
-        discord.sessionKey({
-          groupSessionsPerUser: true,
-          threadSessionsPerUser: false,
-        }),
-      )
-      .reply(discord.replyToOriginThread())
-      .defaults({
-        behavior: {
-          allowedChannels: config.allowedChannels,
-          freeResponseChannels: config.freeResponseChannels,
-          requireMention: config.requireMention,
-          threadRequireMention: config.threadRequireMention,
-          autoThread: false,
-        },
-        toolsets: ['discord'],
+}).agent('main', mainAgent);
+
+// Scheduled supervisor cron binding (opt-in).
+if (supervisorCron) {
+  runtime
+    .agent('supervisor-scan', scanAgent)
+    .on(cron.schedule(supervisorCron), (binding) =>
+      binding
+        .name('supervisor-scan')
+        .toAgent('supervisor-scan')
+        .conversation(({ job }) => `cron:${job.id}`)
+        .input('quarantine scan'),
+    );
+}
+
+runtime.on(discord.messages(), (binding) =>
+  binding
+    .where(discord.notBot())
+    .toAgent('main')
+    .conversation(
+      discord.sessionKey({
+        groupSessionsPerUser: true,
+        threadSessionsPerUser: false,
       }),
-  );
+    )
+    .reply(discord.replyToOriginThread())
+    .defaults({
+      behavior: {
+        allowedChannels: config.allowedChannels,
+        freeResponseChannels: config.freeResponseChannels,
+        requireMention: config.requireMention,
+        threadRequireMention: config.threadRequireMention,
+        autoThread: false,
+      },
+      toolsets: ['discord'],
+    }),
+);
 const bundle = runtime.bundle('claw-discord');
 
 const server = PromptTrail.server({
@@ -154,6 +207,7 @@ const server = PromptTrail.server({
   presence: { kind: 'typing' },
   errorMessage: 'Claw failed to handle that message.',
   adapters: [
+    ...(supervisorCron ? [cronGateway()] : []),
     discordGateway({
       token: config.token,
       stripBotMention: true,

--- a/claw/src/skills/author-skill.ts
+++ b/claw/src/skills/author-skill.ts
@@ -161,8 +161,9 @@ export function createAuthorSkill(options: AuthorSkillOptions): Skill {
     trigger: {
       channel: authoringChannels.length > 0 ? authoringChannels : undefined,
       predicateKey: `startsWith:${AUTHOR_PREFIX}`,
-      when: (content) =>
-        content.trimStart().toLowerCase().startsWith(AUTHOR_PREFIX),
+      // Match `!skill` as a whole word so it never swallows the supervisor's
+      // `!skills` command (both share the `!skill` prefix).
+      when: (content) => /^!skill(\s|$)/i.test(content.trimStart()),
     },
     behavior: (agent) =>
       agent.transform(

--- a/claw/src/skills/authoring.test.ts
+++ b/claw/src/skills/authoring.test.ts
@@ -130,7 +130,9 @@ describe('authoring end-to-end (subprocess: full gate)', () => {
     expect(lastContent(missed)).toBe('ack: unrelated');
 
     const row = registry.get('weather');
-    expect(row?.tier).toBe('staged');
+    // Phase 2: the authoring flow activates a gate-passed skill into 'canary'
+    // (live but closely watched), recording the staged→canary transition.
+    expect(row?.tier).toBe('canary');
     expect(row?.manifestHash).toBe(gate.result.manifestHash);
     expect(row?.activeVersion).toBe(gate.result.manifestHash);
     expect(registry.listVersions('weather')).toHaveLength(1);
@@ -250,7 +252,7 @@ describe('authorization boundary', () => {
       deps: { loaderContext: ctx, synthesizer: templateSynthesizer },
     });
     expect(reply).toContain('Authored and activated');
-    expect(registry.get('hola')?.tier).toBe('staged');
+    expect(registry.get('hola')?.tier).toBe('canary');
     registry.close();
   }, 120_000);
 

--- a/claw/src/skills/dispatch.ts
+++ b/claw/src/skills/dispatch.ts
@@ -1,5 +1,6 @@
 import { Agent, type Session } from '@prompttrail/core';
 import { SkillRegistry } from './registry.js';
+import { evaluateSupervision, type SupervisionConfig } from './supervisor.js';
 import { MATCHED_SKILL_VAR, type Skill, type SkillContext } from './types.js';
 
 /**
@@ -62,6 +63,11 @@ export class SkillDispatcher {
 
   match(ctx: SkillContext): Skill | undefined {
     for (const row of this.registry.listEnabled()) {
+      if (row.tier === 'quarantined') {
+        // Quarantined skills are skipped exactly like disabled ones (§9); the
+        // supervisor must !restore them before they dispatch again.
+        continue;
+      }
       const skill = this.skills.get(row.behaviorRef);
       if (!skill) {
         // Unknown ref: warned at boot (validateSkillRegistry); skip at runtime.
@@ -80,17 +86,29 @@ export class SkillDispatcher {
 
 /**
  * Runs a skill's behavior subroutine and records the outcome to the registry
- * health record (design-docs §9 Phase 0 slice). This explicit wrapper sits in
- * the dispatch path so every skill invocation is instrumented: invocations,
- * successes, consecutiveFailures, lastError, lastLatencyMs.
+ * health record (design-docs §9). This explicit wrapper sits in the dispatch
+ * path so every skill invocation is instrumented: invocations, successes,
+ * consecutiveFailures, lastError, lastLatencyMs.
+ *
+ * When a {@link SupervisionConfig} is supplied it also runs the cheap,
+ * data-plane REACTIVE supervision step after recording health: auto-promote a
+ * clean canary, or auto-quarantine a skill past its failure threshold (both are
+ * registry writes; the supervisor is never on the blocking path). Builtin skills
+ * (status, author, supervisor itself) are left untouched by supervision.
  */
 export async function runSkillInstrumented(
   registry: SkillRegistry,
   skill: Skill,
   session: Session,
   now: () => number = Date.now,
+  supervision?: SupervisionConfig,
 ): Promise<Session> {
   const start = now();
+  const supervise = (): void => {
+    if (supervision) {
+      evaluateSupervision(registry, skill.id, supervision, now);
+    }
+  };
   try {
     const behaviorAgent = skill.behavior(
       Agent.create(`skill-${skill.id.replace(/[^A-Za-z0-9_-]/g, '-')}`),
@@ -100,6 +118,7 @@ export async function runSkillInstrumented(
       success: true,
       latencyMs: Math.max(0, now() - start),
     });
+    supervise();
     return result;
   } catch (error) {
     registry.recordHealth(skill.id, {
@@ -107,6 +126,7 @@ export async function runSkillInstrumented(
       latencyMs: Math.max(0, now() - start),
       error: error instanceof Error ? error.message : String(error),
     });
+    supervise();
     throw error;
   }
 }
@@ -134,6 +154,8 @@ export interface ClawSkillAgentOptions {
   defaultReply: (agent: Agent) => Agent;
   /** Injectable clock for deterministic health latencies in tests. */
   now?: () => number;
+  /** Reactive supervision thresholds (auto-promote / auto-quarantine). */
+  supervision?: SupervisionConfig;
 }
 
 /**
@@ -163,7 +185,13 @@ export function createClawSkillAgent(options: ClawSkillAgentOptions): Agent {
             if (!skill) {
               return session;
             }
-            return runSkillInstrumented(options.registry, skill, session, now);
+            return runSkillInstrumented(
+              options.registry,
+              skill,
+              session,
+              now,
+              options.supervision,
+            );
           },
         ),
       (elseAgent) => options.defaultReply(elseAgent),

--- a/claw/src/skills/index.ts
+++ b/claw/src/skills/index.ts
@@ -10,6 +10,7 @@ export * from './authoring.js';
 export * from './gate.js';
 export * from './loader.js';
 export * from './author-skill.js';
+export * from './supervisor.js';
 
 /**
  * Derive the serializable registry row from an in-process skill. Used for

--- a/claw/src/skills/loader.ts
+++ b/claw/src/skills/loader.ts
@@ -3,7 +3,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { runGate, type GateOptions, type GateResult } from './gate.js';
-import { SkillRegistry } from './registry.js';
+import { SkillRegistry, type SkillTier } from './registry.js';
 import {
   assertSkillModule,
   skillFromModule,
@@ -52,8 +52,22 @@ function durableJsPath(dir: string, id: string): string {
   return join(dir, `${id}.js`);
 }
 
+/**
+ * Per-version, content-addressed artifact paths (design-docs §9). Rollback
+ * imports a *past* version's built `.js`, so every gated build keeps an
+ * immutable copy keyed by manifest hash under `<skillsDir>/versions/`, distinct
+ * from the mutable "live" `<id>.js` that promotion overwrites.
+ */
+export function versionedTsPath(dir: string, id: string, hash: string): string {
+  return join(dir, 'versions', `${id}.${hash}.ts`);
+}
+
+export function versionedJsPath(dir: string, id: string, hash: string): string {
+  return join(dir, 'versions', `${id}.${hash}.js`);
+}
+
 /** Import a built `.js` artifact fresh (cache-busted) and structurally validate it. */
-async function importModule(jsPath: string): Promise<SkillModule> {
+export async function importModule(jsPath: string): Promise<SkillModule> {
   const imported = await import(
     `${pathToFileURL(jsPath).href}?t=${Date.now()}`
   );
@@ -74,6 +88,8 @@ function registerModule(
     gateResult: GateResult | null;
     provenance: SkillProvenance;
     createdAt: string;
+    /** Tier to persist. Fresh promotion passes 'canary'; reload preserves. */
+    tier: SkillTier;
   },
 ): Skill {
   const skill = skillFromModule(module, {
@@ -91,7 +107,7 @@ function registerModule(
     provenance: meta.provenance,
     enabled: true,
     createdAt: meta.createdAt,
-    tier: 'staged',
+    tier: meta.tier,
     sourcePath: durableTs,
     sourceHash: meta.sourceHash,
     manifestHash: meta.manifestHash,
@@ -103,7 +119,11 @@ function registerModule(
       skillId: module.meta.id,
       manifestHash: meta.manifestHash,
       sourceHash: meta.sourceHash,
-      sourcePath: durableTs,
+      sourcePath: versionedTsPath(
+        ctx.skillsDir,
+        module.meta.id,
+        meta.manifestHash,
+      ),
       gateResult: meta.gateResult,
       createdAt: meta.createdAt,
     });
@@ -128,16 +148,57 @@ export function promoteAndRegister(
   },
 ): Skill {
   mkdirSync(ctx.skillsDir, { recursive: true });
+  mkdirSync(join(ctx.skillsDir, 'versions'), { recursive: true });
   const id = args.module.meta.id;
+  const manifestHash = args.gateResult.manifestHash ?? null;
+
+  // Live artifacts (overwritten each promotion) …
   copyFileSync(args.stagingSourcePath, durableTsPath(ctx.skillsDir, id));
   copyFileSync(args.stagingBuiltPath, durableJsPath(ctx.skillsDir, id));
-  return registerModule(ctx, args.module, {
+  // … plus an immutable per-version copy so rollback can re-import a past build.
+  if (manifestHash) {
+    copyFileSync(
+      args.stagingSourcePath,
+      versionedTsPath(ctx.skillsDir, id, manifestHash),
+    );
+    copyFileSync(
+      args.stagingBuiltPath,
+      versionedJsPath(ctx.skillsDir, id, manifestHash),
+    );
+  }
+
+  // Trust tiers (design-docs §9): a gate-passed build lands 'staged', then the
+  // authoring flow immediately ACTIVATES it to 'canary' (live but closely
+  // watched, read-only ceiling). Both transitions are audited; the persisted
+  // tier is the terminal 'canary'.
+  const prev = ctx.registry.get(id);
+  const skill = registerModule(ctx, args.module, {
     sourceHash: hashSource(args.source),
-    manifestHash: args.gateResult.manifestHash ?? null,
+    manifestHash,
     gateResult: args.gateResult,
     provenance: args.provenance,
     createdAt: args.provenance.createdAt,
+    tier: 'canary',
   });
+  const at = args.provenance.createdAt;
+  const actor = args.provenance.authoredBy;
+  ctx.registry.recordAudit({
+    skillId: id,
+    from: prev?.tier ?? '(new)',
+    to: 'staged',
+    reason: `gate passed (${args.gateResult.manifestHash ?? 'no-hash'})`,
+    actor,
+    at,
+  });
+  ctx.registry.recordAudit({
+    skillId: id,
+    from: 'staged',
+    to: 'canary',
+    reason: 'activated (live, read-only ceiling, close watch)',
+    actor,
+    at,
+  });
+  return skill;
 }
 
 /**
@@ -166,7 +227,9 @@ export async function loadStagedSkills(
       const jsPath = durableJsPath(ctx.skillsDir, row.id);
 
       if (row.sourceHash === currentHash && existsSync(jsPath)) {
-        // Fast path: prior gate is still valid for this exact source.
+        // Fast path: prior gate is still valid for this exact source. Preserve
+        // the persisted tier (canary/trusted/quarantined) — a restart must not
+        // silently re-stage a promoted skill or un-quarantine a broken one.
         const module = await importModule(jsPath);
         loaded.push(
           registerModule(ctx, module, {
@@ -175,6 +238,7 @@ export async function loadStagedSkills(
             gateResult: (row.gateResult as GateResult | null) ?? null,
             provenance: row.provenance,
             createdAt: row.createdAt,
+            tier: row.tier,
           }),
         );
         continue;

--- a/claw/src/skills/registry.ts
+++ b/claw/src/skills/registry.ts
@@ -30,8 +30,27 @@ import type { SkillProvenance } from './types.js';
  *   - `gateResult`    — the recorded gate outcome JSON (provenance).
  */
 
-/** Trust tier of a skill (design-docs §9). Phase 1 lands builtin + staged. */
-export type SkillTier = 'builtin' | 'staged';
+/**
+ * Trust tier of a skill (design-docs §9).
+ *   - 'builtin'     — hand-written, trusted, outside the self-authoring loop.
+ *   - 'staged'      — gate-passed but not yet activated (a transient logical
+ *                     state; the authoring flow immediately activates to canary).
+ *   - 'canary'      — live and dispatching, but flagged for close watching and
+ *                     capped at the read-only ceiling (Phase 1 behavior IS this).
+ *   - 'trusted'     — auto-promoted from canary after N clean invocations; still
+ *                     read-only in Phase 2 (write elevation is deferred).
+ *   - 'quarantined' — auto- or hand-demoted past the failure threshold; the
+ *                     dispatcher skips it exactly like a disabled row.
+ */
+export type SkillTier =
+  | 'builtin'
+  | 'staged'
+  | 'canary'
+  | 'trusted'
+  | 'quarantined';
+
+/** Live tiers whose failure/clean-run streaks the supervisor evaluates. */
+export const LIVE_TIERS: readonly SkillTier[] = ['canary', 'trusted'];
 
 /** A persisted skill row (the serializable subset of a Skill + provenance). */
 export interface SkillRegistryRow {
@@ -88,6 +107,36 @@ export interface SkillHealthUpdate {
   error?: string;
 }
 
+/**
+ * Provenance/audit row: one per tier transition (design-docs §9, §10 Phase 2).
+ * `from`/`to` are tier names for tier moves and short manifest hashes for a
+ * rollback; `actor` is 'auto' (supervisor logic) or an author/supervisor id.
+ */
+export interface SkillAuditRow {
+  skillId: string;
+  from: string;
+  to: string;
+  reason: string;
+  actor: string;
+  at: string;
+}
+
+/**
+ * A buffered reactive-supervisor notice (design-docs §9). Delivering a message
+ * to CLAW_SUPERVISOR_CHANNEL from inside the health wrapper is awkward in claw's
+ * message-triggered binding model (the wrapper runs while replying to the
+ * *triggering* message, with no handle to a different channel), so an
+ * auto-quarantine records a durable pending-notice row instead. The next
+ * supervisor command (`!skills`/`!why`) or the scheduled scan surfaces it.
+ */
+export interface SkillNoticeRow {
+  id: number;
+  skillId: string;
+  message: string;
+  createdAt: string;
+  delivered: boolean;
+}
+
 interface SkillRow {
   id: string;
   name: string;
@@ -122,6 +171,23 @@ interface HealthRow {
   last_error: string | null;
   last_latency_ms: number | null;
   updated_at: string;
+}
+
+interface AuditRow {
+  skill_id: string;
+  from_tier: string;
+  to_tier: string;
+  reason: string;
+  actor: string;
+  at: string;
+}
+
+interface NoticeRow {
+  id: number;
+  skill_id: string;
+  message: string;
+  created_at: string;
+  delivered: number;
 }
 
 export class SkillRegistry {
@@ -167,6 +233,22 @@ export class SkillRegistry {
         last_error TEXT,
         last_latency_ms INTEGER,
         updated_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS skill_audit (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        skill_id TEXT NOT NULL,
+        from_tier TEXT NOT NULL,
+        to_tier TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS skill_notices (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        skill_id TEXT NOT NULL,
+        message TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        delivered INTEGER NOT NULL DEFAULT 0
       );
     `);
     this.migrateSkillColumns();
@@ -274,6 +356,27 @@ export class SkillRegistry {
       .run(enabled ? 1 : 0, id);
   }
 
+  /** Move a skill's trust tier (design-docs §9); a pure registry write. */
+  setTier(id: string, tier: SkillTier): void {
+    this.db.prepare('UPDATE skills SET tier = ? WHERE id = ?').run(tier, id);
+  }
+
+  /**
+   * Repoint the active-version pointer (design-docs §9 rollback). Moves
+   * `active_version` and mirrors the build's `manifest_hash`/`source_hash` so a
+   * later restart's fast-path reload trusts the rolled-back build.
+   */
+  setActiveVersion(
+    id: string,
+    version: { manifestHash: string; sourceHash: string | null },
+  ): void {
+    this.db
+      .prepare(
+        'UPDATE skills SET active_version = ?, manifest_hash = ?, source_hash = ? WHERE id = ?',
+      )
+      .run(version.manifestHash, version.manifestHash, version.sourceHash, id);
+  }
+
   /** Append an immutable version row (design-docs §9); idempotent per hash. */
   recordVersion(version: SkillVersionRow): void {
     this.db
@@ -367,6 +470,76 @@ export class SkillRegistry {
     };
   }
 
+  /** Clear the consecutive-failure streak and last error (design-docs §9 restore). */
+  resetConsecutiveFailures(skillId: string): void {
+    this.db
+      .prepare(
+        'UPDATE skill_health SET consecutive_failures = 0, last_error = NULL, updated_at = ? WHERE skill_id = ?',
+      )
+      .run(new Date().toISOString(), skillId);
+  }
+
+  /** Append a provenance/audit row for one tier transition (design-docs §9). */
+  recordAudit(entry: SkillAuditRow): void {
+    this.db
+      .prepare(
+        `INSERT INTO skill_audit (skill_id, from_tier, to_tier, reason, actor, at)
+         VALUES (@skill_id, @from_tier, @to_tier, @reason, @actor, @at)`,
+      )
+      .run({
+        skill_id: entry.skillId,
+        from_tier: entry.from,
+        to_tier: entry.to,
+        reason: entry.reason,
+        actor: entry.actor,
+        at: entry.at,
+      });
+  }
+
+  /** Recent audit rows for a skill, newest first (default 10). */
+  listAudit(skillId: string, limit = 10): SkillAuditRow[] {
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM skill_audit WHERE skill_id = ? ORDER BY id DESC LIMIT ?',
+      )
+      .all(skillId, limit) as AuditRow[];
+    return rows.map(fromAuditRow);
+  }
+
+  /** Buffer a reactive-supervisor notice for later delivery (design-docs §9). */
+  recordNotice(notice: { skillId: string; message: string; at: string }): void {
+    this.db
+      .prepare(
+        `INSERT INTO skill_notices (skill_id, message, created_at, delivered)
+         VALUES (?, ?, ?, 0)`,
+      )
+      .run(notice.skillId, notice.message, notice.at);
+  }
+
+  /** Undelivered notices, oldest first. */
+  listPendingNotices(): SkillNoticeRow[] {
+    const rows = this.db
+      .prepare('SELECT * FROM skill_notices WHERE delivered = 0 ORDER BY id')
+      .all() as NoticeRow[];
+    return rows.map(fromNoticeRow);
+  }
+
+  /** Mark notices delivered so a later command/scan does not re-report them. */
+  markNoticesDelivered(ids: readonly number[]): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const stmt = this.db.prepare(
+      'UPDATE skill_notices SET delivered = 1 WHERE id = ?',
+    );
+    const tx = this.db.transaction((batch: readonly number[]) => {
+      for (const id of batch) {
+        stmt.run(id);
+      }
+    });
+    tx(ids);
+  }
+
   close(): void {
     this.db.close();
   }
@@ -435,5 +608,26 @@ function fromVersionRow(row: VersionRow): SkillVersionRow {
     sourcePath: row.source_path,
     gateResult: parseJsonOrNull(row.gate_result),
     createdAt: row.created_at,
+  };
+}
+
+function fromAuditRow(row: AuditRow): SkillAuditRow {
+  return {
+    skillId: row.skill_id,
+    from: row.from_tier,
+    to: row.to_tier,
+    reason: row.reason,
+    actor: row.actor,
+    at: row.at,
+  };
+}
+
+function fromNoticeRow(row: NoticeRow): SkillNoticeRow {
+  return {
+    id: row.id,
+    skillId: row.skill_id,
+    message: row.message,
+    createdAt: row.created_at,
+    delivered: row.delivered === 1,
   };
 }

--- a/claw/src/skills/supervisor.test.ts
+++ b/claw/src/skills/supervisor.test.ts
@@ -1,0 +1,574 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Agent, Session, Source } from '@prompttrail/core';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import {
+  createClawSkillAgent,
+  createSupervisorSkill,
+  findClawRoot,
+  promoteAndRegister,
+  quarantineScan,
+  runGate,
+  runSkillInstrumented,
+  runSupervisorCommand,
+  SkillRegistry,
+  supervisorAuthorized,
+  templateSynthesizer,
+  type Skill,
+  type SkillLoaderContext,
+  type SkillProvenance,
+  type SkillRegistryRow,
+  type SupervisionConfig,
+} from './index.js';
+
+const provenance: SkillProvenance = {
+  authoredBy: 'test',
+  motivation: 'phase-2 supervision test',
+  createdAt: '2026-07-08T00:00:00.000Z',
+};
+
+const supervision: SupervisionConfig = { promoteAfter: 3, quarantineAfter: 3 };
+
+const echoDefault = (agent: Agent): Agent =>
+  agent.assistant(
+    'reply',
+    (session: Session) => `ack: ${session.getLastMessage()?.content ?? ''}`,
+  );
+
+function userSession(content: string, channel?: string): Session {
+  return Session.create().addMessage({
+    type: 'user',
+    content,
+    attrs: channel ? { channel } : undefined,
+  });
+}
+
+function lastContent(session: Session): string {
+  return session.getLastMessage()?.content ?? '';
+}
+
+/** A registry row for a self-authored skill parked at a given tier. */
+function row(id: string, tier: SkillRegistryRow['tier']): SkillRegistryRow {
+  return {
+    id,
+    name: id,
+    channel: null,
+    predicateKey: `startsWith:!${id}`,
+    behaviorRef: id,
+    provenance,
+    enabled: true,
+    createdAt: provenance.createdAt,
+    tier,
+    sourcePath: null,
+    sourceHash: null,
+    manifestHash: `hash-${id}`,
+    activeVersion: `hash-${id}`,
+    gateResult: { passed: true, stages: [{ name: 'typecheck', ok: true }] },
+  };
+}
+
+function okSkill(id: string): Skill {
+  return {
+    id,
+    name: id,
+    trigger: {
+      predicateKey: `startsWith:!${id}`,
+      when: (c) => c.startsWith(`!${id}`),
+    },
+    behavior: (agent) => agent.assistant(Source.literal('ok')),
+    provenance,
+  };
+}
+
+function boomSkill(id: string): Skill {
+  return {
+    id,
+    name: id,
+    trigger: {
+      predicateKey: `startsWith:!${id}`,
+      when: (c) => c.startsWith(`!${id}`),
+    },
+    behavior: (agent) =>
+      agent.assistant(
+        Source.callback(async () => {
+          throw new Error('boom');
+        }),
+      ),
+    provenance,
+  };
+}
+
+describe('reactive supervision (health wrapper)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'claw-sup-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('auto-quarantines a canary after K consecutive failures, with notice + audit', async () => {
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('boom', 'canary'));
+    const skill = boomSkill('boom');
+
+    for (let i = 0; i < supervision.quarantineAfter; i += 1) {
+      await expect(
+        runSkillInstrumented(
+          registry,
+          skill,
+          userSession('!boom'),
+          Date.now,
+          supervision,
+        ),
+      ).rejects.toThrow('boom');
+    }
+
+    expect(registry.get('boom')?.tier).toBe('quarantined');
+    const audit = registry.listAudit('boom');
+    expect(audit[0]).toMatchObject({ to: 'quarantined', actor: 'auto' });
+    const notices = registry.listPendingNotices();
+    expect(notices.map((n) => n.skillId)).toContain('boom');
+    registry.close();
+  });
+
+  it('auto-promotes a clean canary to trusted after N successes, with audit', async () => {
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('good', 'canary'));
+    const skill = okSkill('good');
+
+    for (let i = 0; i < supervision.promoteAfter; i += 1) {
+      await runSkillInstrumented(
+        registry,
+        skill,
+        userSession('!good'),
+        Date.now,
+        supervision,
+      );
+    }
+
+    expect(registry.get('good')?.tier).toBe('trusted');
+    expect(registry.listAudit('good')[0]).toMatchObject({
+      from: 'canary',
+      to: 'trusted',
+      actor: 'auto',
+    });
+    registry.close();
+  });
+
+  it('does not touch builtin skills', async () => {
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('bi', 'builtin'));
+    const skill = okSkill('bi');
+    for (let i = 0; i < 5; i += 1) {
+      await runSkillInstrumented(
+        registry,
+        skill,
+        userSession('!bi'),
+        Date.now,
+        supervision,
+      );
+    }
+    expect(registry.get('bi')?.tier).toBe('builtin');
+    registry.close();
+  });
+});
+
+describe('dispatcher tier handling', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'claw-sup-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('skips a quarantined skill exactly like a disabled one', async () => {
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('q', 'quarantined'));
+    const skills = new Map<string, Skill>([['q', okSkill('q')]]);
+    const agent = createClawSkillAgent({
+      registry,
+      skills,
+      defaultReply: echoDefault,
+      supervision,
+    });
+    const out = await agent.execute({ session: userSession('!q now') });
+    expect(lastContent(out)).toBe('ack: !q now');
+    registry.close();
+  });
+
+  it('dispatches a canary/trusted skill normally', async () => {
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('c', 'canary'));
+    const skills = new Map<string, Skill>([['c', okSkill('c')]]);
+    const agent = createClawSkillAgent({
+      registry,
+      skills,
+      defaultReply: echoDefault,
+      supervision,
+    });
+    const out = await agent.execute({ session: userSession('!c go') });
+    expect(lastContent(out)).toBe('ok');
+    registry.close();
+  });
+});
+
+describe('supervisor commands', () => {
+  let tmp: string;
+  let registry: SkillRegistry;
+  let ctx: SkillLoaderContext;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'claw-sup-'));
+    registry = new SkillRegistry(join(tmp, 's.db'));
+    ctx = {
+      registry,
+      skills: new Map<string, Skill>(),
+      skillsDir: join(tmp, 'skills'),
+      replySource: Source.callback(async () => 'reply'),
+      gateOptions: {
+        clawRoot: findClawRoot(),
+        stagingRoot: join(tmp, 'staging'),
+      },
+    };
+  });
+  afterEach(() => {
+    registry.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('!promote steps staged→canary then canary→trusted, auditing each', async () => {
+    registry.upsert(row('p', 'staged'));
+    const r1 = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!promote p',
+      'alice',
+    );
+    expect(r1).toContain('staged → canary');
+    expect(registry.get('p')?.tier).toBe('canary');
+
+    const r2 = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!promote p',
+      'alice',
+    );
+    expect(r2).toContain('canary → trusted');
+    expect(registry.get('p')?.tier).toBe('trusted');
+
+    const r3 = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!promote p',
+      'alice',
+    );
+    expect(r3).toContain('Cannot promote');
+
+    const audit = registry.listAudit('p');
+    expect(audit.map((a) => `${a.from}->${a.to}`)).toEqual([
+      'canary->trusted',
+      'staged->canary',
+    ]);
+    expect(audit.every((a) => a.actor === 'alice')).toBe(true);
+  });
+
+  it('!quarantine then !restore resets the consecutive-failure streak', async () => {
+    registry.upsert(row('r', 'canary'));
+    registry.recordHealth('r', { success: false, latencyMs: 1, error: 'x' });
+    registry.recordHealth('r', { success: false, latencyMs: 1, error: 'x' });
+    expect(registry.getHealth('r')?.consecutiveFailures).toBe(2);
+
+    const q = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!quarantine r',
+      'bob',
+    );
+    expect(q).toContain('→ quarantined');
+    expect(registry.get('r')?.tier).toBe('quarantined');
+
+    const res = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!restore r',
+      'bob',
+    );
+    expect(res).toContain('quarantined → canary');
+    expect(registry.get('r')?.tier).toBe('canary');
+    expect(registry.getHealth('r')?.consecutiveFailures).toBe(0);
+    expect(registry.getHealth('r')?.lastError).toBeNull();
+  });
+
+  it('!skills lists tiers and drains pending notices; !why shows audit + gate', async () => {
+    registry.upsert(row('a', 'canary'));
+    registry.recordNotice({
+      skillId: 'a',
+      message: 'test notice',
+      at: provenance.createdAt,
+    });
+
+    const list = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!skills',
+      'sup',
+    );
+    expect(list).toContain('Supervisor notices (1)');
+    expect(list).toContain('a: test notice');
+    expect(list).toContain('tier=canary');
+    // Notices are drained (delivered) after being surfaced once.
+    expect(registry.listPendingNotices()).toHaveLength(0);
+
+    await runSupervisorCommand({ loaderContext: ctx }, '!quarantine a', 'sup');
+    const why = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!why a',
+      'sup',
+    );
+    expect(why).toContain('why a');
+    expect(why).toContain('→ quarantined');
+    expect(why).toContain('gate:');
+  });
+
+  it('rejects unknown skills and bad usage', async () => {
+    expect(
+      await runSupervisorCommand({ loaderContext: ctx }, '!promote', 'x'),
+    ).toContain('Usage');
+    expect(
+      await runSupervisorCommand({ loaderContext: ctx }, '!why ghost', 'x'),
+    ).toContain('Unknown skill');
+    expect(
+      await runSupervisorCommand({ loaderContext: ctx }, '!nope', 'x'),
+    ).toContain('Unknown supervisor command');
+  });
+});
+
+describe('supervisor command channel/author gating', () => {
+  it('supervisorAuthorized enforces channel and author allowlists', () => {
+    expect(
+      supervisorAuthorized({
+        channel: 'random',
+        supervisorChannels: ['control'],
+        authors: [],
+      }),
+    ).toContain('not permitted in this channel');
+    expect(
+      supervisorAuthorized({
+        channel: 'control',
+        authorId: '999',
+        supervisorChannels: ['control'],
+        authors: ['123'],
+      }),
+    ).toContain('allowlist');
+    expect(
+      supervisorAuthorized({
+        channel: 'control',
+        authorId: '123',
+        supervisorChannels: ['control'],
+        authors: ['123'],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('the supervisor skill runs only in its channel via dispatch', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'claw-sup-'));
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    const ctx: SkillLoaderContext = {
+      registry,
+      skills: new Map<string, Skill>(),
+      skillsDir: join(tmp, 'skills'),
+      replySource: Source.callback(async () => 'reply'),
+      gateOptions: {
+        clawRoot: findClawRoot(),
+        stagingRoot: join(tmp, 'staging'),
+      },
+    };
+    const supervisorSkill = createSupervisorSkill({
+      loaderContext: ctx,
+      supervisorChannels: ['control'],
+      authors: [],
+    });
+    registry.upsert({
+      id: supervisorSkill.id,
+      name: supervisorSkill.name,
+      channel: supervisorSkill.trigger.channel ?? null,
+      predicateKey: supervisorSkill.trigger.predicateKey,
+      behaviorRef: supervisorSkill.id,
+      provenance: supervisorSkill.provenance,
+      enabled: true,
+      createdAt: supervisorSkill.provenance.createdAt,
+      tier: 'builtin',
+      sourcePath: null,
+      sourceHash: null,
+      manifestHash: null,
+      activeVersion: null,
+      gateResult: null,
+    });
+    ctx.skills.set(supervisorSkill.id, supervisorSkill);
+
+    const agent = createClawSkillAgent({
+      registry,
+      skills: ctx.skills,
+      defaultReply: echoDefault,
+    });
+
+    // Wrong channel: trigger channel narrowing means the skill never matches.
+    const wrong = await agent.execute({
+      session: userSession('!skills', 'random'),
+    });
+    expect(lastContent(wrong)).toBe('ack: !skills');
+
+    // Right channel: the supervisor command runs.
+    const right = await agent.execute({
+      session: userSession('!skills', 'control'),
+    });
+    expect(lastContent(right)).toContain('Skills (');
+    registry.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('scheduled scan', () => {
+  it('quarantines a skill that failed while idle (direct scan call)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'claw-sup-'));
+    const registry = new SkillRegistry(join(tmp, 's.db'));
+    registry.upsert(row('idle', 'canary'));
+    registry.upsert(row('healthy', 'canary'));
+    // 'idle' accrued failures without the reactive wrapper firing (e.g. failed
+    // deliveries recorded out-of-band).
+    for (let i = 0; i < 3; i += 1) {
+      registry.recordHealth('idle', {
+        success: false,
+        latencyMs: 1,
+        error: 'stale',
+      });
+    }
+
+    const quarantined = quarantineScan(registry, supervision);
+    expect(quarantined).toEqual(['idle']);
+    expect(registry.get('idle')?.tier).toBe('quarantined');
+    expect(registry.get('healthy')?.tier).toBe('canary');
+    expect(registry.listAudit('idle')[0]).toMatchObject({
+      to: 'quarantined',
+      actor: 'auto',
+    });
+    expect(registry.listPendingNotices().map((n) => n.skillId)).toContain(
+      'idle',
+    );
+    registry.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});
+
+describe('rollback (subprocess: full gate, two versions)', () => {
+  const clawRoot = findClawRoot();
+  let base: string;
+  beforeAll(() => {
+    mkdirSync(join(clawRoot, '.data'), { recursive: true });
+    base = mkdtempSync(join(clawRoot, '.data', 'rollback-test-'));
+  });
+  afterAll(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // v1/v2 differ by a serializable system-prompt literal (so their manifest
+  // hashes differ — closure bodies alone are not hashed) AND by the var each
+  // sets, which the injected reply source surfaces to make them observable.
+  const version = (marker: string, value: string) =>
+    `import type { Agent, Source } from '@prompttrail/core';
+export const meta = { id: 'ver', name: 'Ver', description: '${value}' };
+export const trigger = { startsWith: '!ver' };
+export const examples: string[] = ['!ver'];
+export function behavior(agent: Agent, reply: Source<string>): Agent {
+  return agent
+    .system('behavior ${value}')
+    .transform('${marker}', (session) => session.withVar('ver', '${value}'))
+    .assistant('reply', reply);
+}
+`;
+
+  it('author v1, author v2 (same id), rollback → v1 behavior dispatches again', async () => {
+    const registry = new SkillRegistry(join(base, 'skills.db'));
+    const skills = new Map<string, Skill>();
+    const ctx: SkillLoaderContext = {
+      registry,
+      skills,
+      skillsDir: join(base, 'skills'),
+      // The injected reply surfaces the version marker each behavior sets.
+      replySource: Source.callback(async ({ context }) =>
+        String((context as Record<string, unknown> | undefined)?.ver ?? 'none'),
+      ),
+      gateOptions: { clawRoot, stagingRoot: join(base, 'staging') },
+    };
+
+    // Distinct STAGING ids (the modules both carry meta.id 'ver') so the two
+    // gate builds live at different paths — vitest's import layer caches an
+    // absolute path across `?t=` queries, unlike plain Node used in production.
+    const g1 = await runGate(
+      { id: 'ver-1', source: version('mark1', 'v1') },
+      ctx.gateOptions,
+    );
+    expect(g1.result.passed).toBe(true);
+    promoteAndRegister(ctx, {
+      module: g1.module!,
+      stagingSourcePath: g1.sourcePath!,
+      stagingBuiltPath: g1.builtPath!,
+      source: version('mark1', 'v1'),
+      gateResult: g1.result,
+      provenance,
+    });
+
+    const g2 = await runGate(
+      { id: 'ver-2', source: version('mark2', 'v2') },
+      ctx.gateOptions,
+    );
+    expect(g2.result.passed).toBe(true);
+    expect(g2.result.manifestHash).not.toBe(g1.result.manifestHash);
+    promoteAndRegister(ctx, {
+      module: g2.module!,
+      stagingSourcePath: g2.sourcePath!,
+      stagingBuiltPath: g2.builtPath!,
+      source: version('mark2', 'v2'),
+      gateResult: g2.result,
+      provenance,
+    });
+
+    expect(registry.listVersions('ver')).toHaveLength(2);
+    expect(registry.get('ver')?.activeVersion).toBe(g2.result.manifestHash);
+
+    const build = () =>
+      createClawSkillAgent({ registry, skills, defaultReply: echoDefault });
+
+    // v2 is active.
+    const before = await build().execute({ session: userSession('!ver go') });
+    expect(lastContent(before)).toBe('v2');
+
+    // Roll the active-version pointer back to v1 and re-dispatch.
+    const msg = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!rollback ver',
+      'ops',
+    );
+    expect(msg).toContain('Rolled "ver" back');
+    expect(registry.get('ver')?.activeVersion).toBe(g1.result.manifestHash);
+
+    const after = await build().execute({ session: userSession('!ver go') });
+    expect(lastContent(after)).toBe('v1');
+
+    // A rollback audit row exists; and no earlier version to roll back to now.
+    expect(
+      registry.listAudit('ver').some((a) => a.reason.includes('rollback')),
+    ).toBe(true);
+    const again = await runSupervisorCommand(
+      { loaderContext: ctx },
+      '!rollback ver',
+      'ops',
+    );
+    expect(again).toContain('no previous version');
+    registry.close();
+  }, 180_000);
+});

--- a/claw/src/skills/supervisor.ts
+++ b/claw/src/skills/supervisor.ts
@@ -1,0 +1,558 @@
+import type { SkillLoaderContext } from './loader.js';
+import { importModule, versionedJsPath } from './loader.js';
+import {
+  LIVE_TIERS,
+  type SkillHealthRecord,
+  type SkillRegistry,
+  type SkillRegistryRow,
+  type SkillTier,
+} from './registry.js';
+import { skillFromModule } from './skill-module.js';
+import type { Skill } from './types.js';
+
+/**
+ * The control plane (design-docs/claw-self-authoring.md §9, §10 Phase 2).
+ *
+ * The supervisor is human-authored, trusted, in-repo code OUTSIDE the
+ * self-authoring loop — it observes the per-skill health record and moves trust
+ * tiers, but never sits on the per-message hot path. It has three invocation
+ * modes, none per-wakeup:
+ *
+ *   - reactive  — {@link evaluateSupervision}, run by the health wrapper after
+ *                 each skill invocation: auto-promote a clean canary, or
+ *                 auto-quarantine a skill past its failure threshold (and buffer
+ *                 a reactive notice, since the wrapper cannot address a foreign
+ *                 channel — see registry.ts SkillNoticeRow).
+ *   - scheduled — {@link quarantineScan}, an optional cron scan that catches
+ *                 skills which failed while idle (same threshold logic).
+ *   - on-demand — the privileged `supervisor` skill's channel commands
+ *                 ({@link createSupervisorSkill}): !skills / !promote /
+ *                 !quarantine / !restore / !rollback / !why.
+ *
+ * Capability elevation (write effects) is explicitly NOT in Phase 2: the gate
+ * still rejects external writes, so `!promote` only raises the trust tier, never
+ * the capability ceiling. The read-only ceiling holds for every self-authored
+ * skill at every tier. See README "Skills (Phase 2)".
+ */
+
+export interface SupervisionConfig {
+  /** Auto-promote canary → trusted after this many clean invocations. */
+  promoteAfter: number;
+  /** Auto-quarantine at this many consecutive failures. */
+  quarantineAfter: number;
+  /** Channel a reactive notice is intended for (buffered, surfaced by commands). */
+  supervisorChannel?: string;
+}
+
+/** Result of one supervision evaluation (for the wrapper's optional logging). */
+export interface SupervisionOutcome {
+  quarantined?: boolean;
+  promoted?: boolean;
+}
+
+function isoAt(now: () => number): string {
+  return new Date(now()).toISOString();
+}
+
+/**
+ * Reactive supervision: evaluate a single skill's health after an invocation.
+ * Cheap and data-plane (a registry write); called by the health wrapper.
+ */
+export function evaluateSupervision(
+  registry: SkillRegistry,
+  skillId: string,
+  config: SupervisionConfig,
+  now: () => number = Date.now,
+): SupervisionOutcome {
+  const row = registry.get(skillId);
+  const health = registry.getHealth(skillId);
+  if (!row || !health) {
+    return {};
+  }
+
+  // Auto-quarantine: consecutive failures at/over the threshold. Applies to any
+  // live tier; the dispatcher then skips the skill exactly like a disabled row.
+  if (
+    LIVE_TIERS.includes(row.tier) &&
+    health.consecutiveFailures >= config.quarantineAfter
+  ) {
+    const at = isoAt(now);
+    registry.setTier(skillId, 'quarantined');
+    registry.recordAudit({
+      skillId,
+      from: row.tier,
+      to: 'quarantined',
+      reason: `auto: ${health.consecutiveFailures} consecutive failures (>= ${config.quarantineAfter})`,
+      actor: 'auto',
+      at,
+    });
+    registry.recordNotice({
+      skillId,
+      message: `auto-quarantined after ${health.consecutiveFailures} consecutive failures — last error: ${
+        health.lastError ?? 'n/a'
+      }`,
+      at,
+    });
+    return { quarantined: true };
+  }
+
+  // Auto-promote: a clean canary that has accrued enough successful invocations.
+  if (
+    row.tier === 'canary' &&
+    health.consecutiveFailures === 0 &&
+    health.successes >= config.promoteAfter
+  ) {
+    registry.setTier(skillId, 'trusted');
+    registry.recordAudit({
+      skillId,
+      from: 'canary',
+      to: 'trusted',
+      reason: `auto: ${health.successes} clean invocations (>= ${config.promoteAfter})`,
+      actor: 'auto',
+      at: isoAt(now),
+    });
+    return { promoted: true };
+  }
+
+  return {};
+}
+
+/**
+ * Scheduled supervision: sweep every live self-authored skill and quarantine
+ * any already over the failure threshold. Catches skills that failed while idle
+ * (the reactive path only fires when a skill is invoked). Returns the ids it
+ * quarantined. A pure registry operation — safe to call directly (tests) or from
+ * a cron binding.
+ */
+export function quarantineScan(
+  registry: SkillRegistry,
+  config: SupervisionConfig,
+  now: () => number = Date.now,
+): string[] {
+  const quarantined: string[] = [];
+  for (const row of registry.list()) {
+    if (row.tier === 'builtin' || !LIVE_TIERS.includes(row.tier)) {
+      continue;
+    }
+    const health = registry.getHealth(row.id);
+    if (!health || health.consecutiveFailures < config.quarantineAfter) {
+      continue;
+    }
+    const at = isoAt(now);
+    registry.setTier(row.id, 'quarantined');
+    registry.recordAudit({
+      skillId: row.id,
+      from: row.tier,
+      to: 'quarantined',
+      reason: `scheduled scan: ${health.consecutiveFailures} consecutive failures (>= ${config.quarantineAfter})`,
+      actor: 'auto',
+      at,
+    });
+    registry.recordNotice({
+      skillId: row.id,
+      message: `quarantined by scheduled scan after ${health.consecutiveFailures} consecutive failures — last error: ${
+        health.lastError ?? 'n/a'
+      }`,
+      at,
+    });
+    quarantined.push(row.id);
+  }
+  return quarantined;
+}
+
+function shortHash(hash: string | null | undefined): string {
+  return hash ? hash.slice(0, 10) : 'n/a';
+}
+
+function health(
+  registry: SkillRegistry,
+  id: string,
+): SkillHealthRecord | undefined {
+  return registry.getHealth(id);
+}
+
+function failureCount(h: SkillHealthRecord | undefined): number {
+  return h ? h.invocations - h.successes : 0;
+}
+
+/** Render the pending-notice banner, marking those notices delivered. */
+function drainNotices(registry: SkillRegistry): string {
+  const pending = registry.listPendingNotices();
+  if (pending.length === 0) {
+    return '';
+  }
+  registry.markNoticesDelivered(pending.map((n) => n.id));
+  const lines = pending.map((n) => `  ! ${n.skillId}: ${n.message}`);
+  return `Supervisor notices (${pending.length}):\n${lines.join('\n')}\n\n`;
+}
+
+function renderSkillsList(registry: SkillRegistry): string {
+  const rows = registry.list();
+  if (rows.length === 0) {
+    return 'No skills registered.';
+  }
+  const lines = rows.map((row) => {
+    const h = health(registry, row.id);
+    return [
+      row.id,
+      `"${row.name}"`,
+      `tier=${row.tier}`,
+      `enabled=${row.enabled}`,
+      `inv=${h?.invocations ?? 0}`,
+      `fail=${failureCount(h)}`,
+      `hash=${shortHash(row.activeVersion ?? row.manifestHash)}`,
+    ].join('  ');
+  });
+  return `Skills (${rows.length}):\n${lines.join('\n')}`;
+}
+
+function renderWhy(registry: SkillRegistry, id: string): string {
+  const row = registry.get(id);
+  if (!row) {
+    return `Unknown skill "${id}".`;
+  }
+  const h = health(registry, id);
+  const gate = row.gateResult as {
+    passed?: boolean;
+    stages?: { name: string; ok: boolean }[];
+  } | null;
+  const gateSummary = gate?.stages
+    ? gate.stages.map((s) => `${s.name}:${s.ok ? 'ok' : 'FAIL'}`).join(' | ')
+    : 'n/a';
+  const audit = registry.listAudit(id, 5);
+  const auditLines =
+    audit.length > 0
+      ? audit
+          .map(
+            (a) => `  ${a.at} ${a.from} → ${a.to} (${a.reason}) [${a.actor}]`,
+          )
+          .join('\n')
+      : '  (none)';
+  return [
+    `why ${id} (tier=${row.tier}, enabled=${row.enabled}):`,
+    `  invocations: ${h?.invocations ?? 0}, successes: ${h?.successes ?? 0}, failures: ${failureCount(h)}, consecutiveFailures: ${h?.consecutiveFailures ?? 0}`,
+    `  lastError: ${h?.lastError ?? 'none'}`,
+    `  lastLatencyMs: ${h?.lastLatencyMs ?? 'n/a'}`,
+    `  activeVersion: ${shortHash(row.activeVersion)} (of ${registry.listVersions(id).length} version(s))`,
+    `  gate: ${gateSummary}`,
+    `  recent audit:`,
+    auditLines,
+  ].join('\n');
+}
+
+/** Bind a rolled-back module's built artifact back into the live skill map. */
+async function rollback(
+  ctx: SkillLoaderContext,
+  id: string,
+  actor: string,
+  now: () => number,
+): Promise<string> {
+  const registry = ctx.registry;
+  const row = registry.get(id);
+  if (!row) {
+    return `Unknown skill "${id}".`;
+  }
+  const versions = registry.listVersions(id);
+  const activeIndex = versions.findIndex(
+    (v) => v.manifestHash === row.activeVersion,
+  );
+  // The immediately-preceding immutable version (insertion order = newest last).
+  const from = activeIndex === -1 ? versions.length - 1 : activeIndex;
+  if (from <= 0) {
+    return `Cannot roll back "${id}": no previous version (only ${versions.length} on record).`;
+  }
+  const prev = versions[from - 1];
+  const jsPath = versionedJsPath(ctx.skillsDir, id, prev.manifestHash);
+  let skill: Skill;
+  try {
+    const module = await importModule(jsPath);
+    skill = skillFromModule(module, {
+      reply: ctx.replySource,
+      provenance: row.provenance,
+    });
+  } catch (error) {
+    return `Rollback of "${id}" failed to load version ${shortHash(
+      prev.manifestHash,
+    )}: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  // Rebind the in-process behavior and repoint the active version (instant —
+  // the parent graph and live conversations are undisturbed, §8/§9).
+  ctx.skills.set(id, skill);
+  registry.setActiveVersion(id, {
+    manifestHash: prev.manifestHash,
+    sourceHash: prev.sourceHash,
+  });
+  registry.recordAudit({
+    skillId: id,
+    from: shortHash(row.activeVersion),
+    to: shortHash(prev.manifestHash),
+    reason: 'rollback (active-version pointer moved)',
+    actor,
+    at: isoAt(now),
+  });
+  return `Rolled "${id}" back to version ${shortHash(prev.manifestHash)} (was ${shortHash(
+    row.activeVersion,
+  )}); it now dispatches the previous behavior.`;
+}
+
+/** A single-tier promote/quarantine/restore, with the audit row. */
+function transition(
+  registry: SkillRegistry,
+  id: string,
+  to: SkillTier,
+  reason: string,
+  actor: string,
+  now: () => number,
+  guard: (row: SkillRegistryRow) => string | undefined,
+): string {
+  const row = registry.get(id);
+  if (!row) {
+    return `Unknown skill "${id}".`;
+  }
+  const rejection = guard(row);
+  if (rejection) {
+    return rejection;
+  }
+  registry.setTier(id, to);
+  registry.recordAudit({
+    skillId: id,
+    from: row.tier,
+    to,
+    reason,
+    actor,
+    at: isoAt(now),
+  });
+  return `${id}: ${row.tier} → ${to} (${reason}).`;
+}
+
+export interface SupervisorCommandDeps {
+  loaderContext: SkillLoaderContext;
+  now?: () => number;
+}
+
+/**
+ * Parse and execute one supervisor command line. Returns the channel-facing
+ * reply. Never throws — bad input becomes a usage/error string. Exported for
+ * tests and for {@link createSupervisorSkill}.
+ */
+export async function runSupervisorCommand(
+  deps: SupervisorCommandDeps,
+  content: string,
+  actor: string,
+): Promise<string> {
+  const registry = deps.loaderContext.registry;
+  const now = deps.now ?? Date.now;
+  const trimmed = content.trim();
+  const [rawCommand, ...rest] = trimmed.split(/\s+/);
+  const command = rawCommand.toLowerCase();
+  const arg = rest[0];
+
+  const requireArg = (): string | undefined =>
+    arg ? undefined : `Usage: ${command} <skill-id>`;
+
+  switch (command) {
+    case '!skills':
+      return drainNotices(registry) + renderSkillsList(registry);
+
+    case '!why': {
+      const usage = requireArg();
+      if (usage) {
+        return usage;
+      }
+      return drainNotices(registry) + renderWhy(registry, arg);
+    }
+
+    case '!promote': {
+      const usage = requireArg();
+      if (usage) {
+        return usage;
+      }
+      const current = registry.get(arg);
+      if (!current) {
+        return `Unknown skill "${arg}".`;
+      }
+      // Promote is ONE step: staged→canary, canary→trusted. Trust tier only —
+      // the read-only capability ceiling is unchanged (Phase 2 defers write
+      // elevation; see README).
+      const target: SkillTier | undefined =
+        current.tier === 'staged'
+          ? 'canary'
+          : current.tier === 'canary'
+            ? 'trusted'
+            : undefined;
+      if (!target) {
+        return `Cannot promote "${arg}" from tier "${current.tier}" (promotable: staged→canary, canary→trusted).`;
+      }
+      return transition(
+        registry,
+        arg,
+        target,
+        'promoted (trust tier only; read-only ceiling unchanged — Phase 2 defers write elevation)',
+        actor,
+        now,
+        () => undefined,
+      );
+    }
+
+    case '!quarantine': {
+      const usage = requireArg();
+      if (usage) {
+        return usage;
+      }
+      return transition(
+        registry,
+        arg,
+        'quarantined',
+        'quarantined by supervisor',
+        actor,
+        now,
+        (row) =>
+          row.tier === 'builtin'
+            ? `Cannot quarantine builtin skill "${arg}".`
+            : undefined,
+      );
+    }
+
+    case '!restore': {
+      const usage = requireArg();
+      if (usage) {
+        return usage;
+      }
+      const result = transition(
+        registry,
+        arg,
+        'canary',
+        'restored from quarantine (consecutive failures reset)',
+        actor,
+        now,
+        (row) =>
+          row.tier === 'quarantined'
+            ? undefined
+            : `Cannot restore "${arg}" from tier "${row.tier}" (only quarantined skills are restorable).`,
+      );
+      if (result.includes('→ canary')) {
+        registry.resetConsecutiveFailures(arg);
+      }
+      return result;
+    }
+
+    case '!rollback': {
+      const usage = requireArg();
+      if (usage) {
+        return usage;
+      }
+      return rollback(deps.loaderContext, arg, actor, now);
+    }
+
+    default:
+      return `Unknown supervisor command "${command}". Try: !skills, !promote <id>, !quarantine <id>, !restore <id>, !rollback <id>, !why <id>.`;
+  }
+}
+
+const SUPERVISOR_COMMANDS = [
+  '!skills',
+  '!promote',
+  '!quarantine',
+  '!restore',
+  '!rollback',
+  '!why',
+] as const;
+
+/** Match a message whose first token is one of the supervisor commands. */
+function isSupervisorCommand(content: string): boolean {
+  const first = content.trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+  return (SUPERVISOR_COMMANDS as readonly string[]).includes(first);
+}
+
+/** Channel + author gate for a supervisor command (matches the author skill). */
+export function supervisorAuthorized(input: {
+  channel?: string;
+  channelId?: string;
+  authorId?: string;
+  authorName?: string;
+  supervisorChannels: string[];
+  authors: string[];
+}): string | undefined {
+  if (input.supervisorChannels.length > 0) {
+    const inChannel =
+      (input.channel !== undefined &&
+        input.supervisorChannels.includes(input.channel)) ||
+      (input.channelId !== undefined &&
+        input.supervisorChannels.includes(input.channelId));
+    if (!inChannel) {
+      return 'Supervisor commands are not permitted in this channel.';
+    }
+  }
+  if (input.authors.length > 0) {
+    const allowed =
+      (input.authorId !== undefined &&
+        input.authors.includes(input.authorId)) ||
+      (input.authorName !== undefined &&
+        input.authors.includes(input.authorName));
+    if (!allowed) {
+      return 'You are not on the supervisor allowlist (CLAW_AUTHORS).';
+    }
+  }
+  return undefined;
+}
+
+export interface SupervisorSkillOptions extends SupervisorCommandDeps {
+  /** Channels the supervisor commands are permitted in (same gating as !skill). */
+  supervisorChannels: string[];
+  /** Optional author allowlist (id or name); empty = any author in-channel. */
+  authors: string[];
+}
+
+/**
+ * The built-in, trusted `supervisor` skill (tier 'builtin', like `status`). It
+ * is a normal registry row — the parent graph stays static — whose behavior runs
+ * the on-demand supervisor commands. Channel narrowing is on the trigger; author
+ * gating is re-checked in-behavior (defense in depth, matching the author skill).
+ */
+export function createSupervisorSkill(options: SupervisorSkillOptions): Skill {
+  const { supervisorChannels, authors } = options;
+  return {
+    id: 'supervisor',
+    name: 'Supervisor',
+    trigger: {
+      channel: supervisorChannels.length > 0 ? supervisorChannels : undefined,
+      predicateKey: `commands:${SUPERVISOR_COMMANDS.join(',')}`,
+      when: (content) => isSupervisorCommand(content),
+    },
+    behavior: (agent) =>
+      agent.transform(
+        'supervise',
+        { effect: { repeatable: true } },
+        async (session) => {
+          const last = session.getLastMessage();
+          const content = last?.content ?? '';
+          const attrs = (last?.attrs ?? {}) as Record<string, unknown>;
+          const rejection = supervisorAuthorized({
+            channel:
+              typeof attrs.channel === 'string' ? attrs.channel : undefined,
+            channelId:
+              typeof attrs.channelId === 'string' ? attrs.channelId : undefined,
+            authorId:
+              typeof attrs.authorId === 'string' ? attrs.authorId : undefined,
+            authorName:
+              typeof attrs.author === 'string' ? attrs.author : undefined,
+            supervisorChannels,
+            authors,
+          });
+          const actor =
+            (typeof attrs.authorId === 'string' && attrs.authorId) ||
+            (typeof attrs.author === 'string' && attrs.author) ||
+            'unknown';
+          const reply =
+            rejection ?? (await runSupervisorCommand(options, content, actor));
+          return session.addMessage({ type: 'assistant', content: reply });
+        },
+      ),
+    provenance: {
+      authoredBy: 'claw-maintainers',
+      motivation:
+        'Trusted Phase 2 control plane: on-demand supervisor commands (!skills, !promote, !quarantine, !restore, !rollback, !why).',
+      createdAt: '2026-07-08T00:00:00.000Z',
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@prompttrail/core':
         specifier: link:../packages/core
         version: link:../packages/core
+      '@prompttrail/cron':
+        specifier: workspace:*
+        version: link:../packages/cron
       '@prompttrail/discord':
         specifier: workspace:*
         version: link:../packages/discord


### PR DESCRIPTION
Implements claw-self-authoring.md §9/§10 Phase 2, all in claw/ (no core changes):

- Tiers: builtin | staged | canary | trusted | quarantined. Authoring activates into canary (live but watched); auto-promotion after N clean runs, auto-quarantine after K consecutive failures — both evaluated in the data-plane health wrapper, both audited
- Supervisor commands as a builtin skill (privileged channels/authors): !skills, !promote, !quarantine, !restore, !rollback, !why — rollback re-imports the previous immutable version artifact and moves the activeVersion pointer
- Invocation modes per design: on-demand (commands), scheduled (CLAW_SUPERVISOR_CRON via cronGateway), reactive (durable notice rows surfaced by the next command/scan — never a blocking proxy on the hot path)
- skill_audit + skill_notices tables; !why shows gate results, health, and recent audit trail
- Deferred per design: Curator, git audit archive, capability elevation (gate still rejects writes; !promote never raises the read-only ceiling)

claw 36 tests (23 + 13), core spot-checks green, typecheck/build/prettier clean.