### PR TITLE
docs: object model (Agent/Conversation/App/Model) and memory compaction

### DIFF
--- a/design-docs/memory-compaction.md
+++ b/design-docs/memory-compaction.md
@@ -1,0 +1,126 @@
+# Memory: append-only compaction and the observation log
+
+Design record for conversation memory (prompt-side) and delta-chain compaction
+(storage-side) — one mechanism, two pressures. Prerequisite for claw roadmap
+item 4. Follows the rule fixed in `positioning-and-claw-roadmap.md` §Memory:
+**summarization must not rewrite history**. No backward-compatibility
+constraint (pre-1.0).
+
+Legend: `[x]` decided · `[ ]` open.
+
+---
+
+## 0. Two growth problems, one append-only answer
+
+| Pressure | Symptom | Where it bites |
+| --- | --- | --- |
+| Prompt growth | long conversations exceed the model context; every turn pays the full history | `Source.llm` prompt assembly |
+| Storage growth | the session delta chain and per-run documents grow without bound; lazy backends re-fold every delta on every read; redis re-serializes the whole doc per append (O(N²) total) | all five store backends |
+
+Both are solved by the same shape: **append a summary, advance a pointer,
+never delete or rewrite what the pointer passed** — Mastra's Observational
+Memory translated into the checkpoint model. The prompt-side pointer and the
+storage-side snapshot are two consumers of one compaction event.
+
+Constraints this must respect (all load-bearing today):
+
+- `session.messages` is the at-rest truth under the checkpoint model; hooks
+  and `once` dependencies may key on session version/lineage
+  (`adoptSessionResult`, delta chaining by `version`). Append-only preserves
+  lineage; rewriting breaks it.
+- Prompt cacheability comes from an append-only prefix.
+- The recording/replay roadmap (B0+) will treat the transcript as the golden
+  record; a rewritten transcript cannot be a golden record.
+
+## 1. The observation log
+
+`[x]` **1.1 Representation: messages with a reserved attr, not a new store
+collection.** A compaction appends an ordinary message —
+`Message.system(summaryText, { 'memory.observation': true, 'memory.through': v })`
+— to the session. It rides the existing delta/persist/reconstruct machinery in
+all five backends for free, survives cold restart, and is visible to
+replay/recording as part of the transcript. A separate collection would need
+new store ops across five backends and would hide the summary from the
+transcript it summarizes.
+
+`[x]` **1.2 The context-assembly pointer.** A session-level field
+`compactedThrough: number` (message index or session version — decide with the
+implementation, version preferred since deltas key on it) advanced by the same
+compaction step, persisted as a var-like part of the delta (`varsSet` is
+sufficient: a reserved `memory.compactedThrough` var; no session schema
+change).
+
+`[x]` **1.3 Prompt assembly rule.** When building the model prompt,
+`Source.llm` (and the provider turns) assemble: system prompts + observation
+messages + messages after `compactedThrough`. Raw messages before the pointer
+leave the **prompt**, never the **journal**. One cache miss per compaction
+(the assembled prefix changes once), then stable again — acceptable and
+documented.
+
+## 2. The compaction step
+
+`[x]` **2.1 An explicit, checkpointed keyed effect.** Compaction runs as an
+effect transform with `idempotencyKey: 'memory.compact:' + throughVersion` —
+the summarizer LLM call is an external effect and must not double-run on
+retry/resume; the once-memo covers it. It appends the observation message and
+advances the pointer in one session transition (one delta).
+
+`[x]` **2.2 Trigger policy lives in the app, mechanics in core.** Core ships
+the `compact` primitive (given a summarizer `Source<string>` and a range);
+the app decides *when*: `PromptTrail.app({ memory: { compactAfterMessages?,
+compactAfterEstTokens?, summarizer? } })` checks the policy at terminal
+boundaries (post-completion/suspension — never mid-node) and enqueues the
+compaction as the first step of the next resume. Token estimation is a cheap
+chars/4 heuristic; precision is not required for a threshold.
+
+`[ ]` **2.3 Summarizer prompt ownership.** Framework default prompt
+(structured: facts, open loops, user preferences) vs app-supplied. Default in
+core, overridable; claw supplies a persona-aware one. Decide at
+implementation.
+
+## 3. Storage snapshot (the second consumer)
+
+`[x]` **3.1 Snapshot = rewrite delta, an existing concept.** The store already
+understands a `rewrite` delta that replaces the folded session. Storage
+compaction folds the chain prefix ≤ version V into one rewrite delta and
+deletes the older delta rows — the folded value is identical by construction,
+so this is invisible to readers and needs **no new store semantics**, only a
+maintenance op: `compactDeltas(runId, throughVersion, fence?)` implemented per
+backend + a conformance case asserting fold-equivalence and idempotency.
+
+`[x]` **3.2 Decoupled from prompt compaction.** Storage snapshotting is safe
+at ANY version (it's a pure fold); running it at the observation-log boundary
+is merely convenient. The app runs it opportunistically after 2.1 commits.
+
+## 4. claw tie-in (roadmap #4)
+
+- The observation log doubles as **conversation-scoped facts**: claw's
+  summarizer prompt extracts durable facts (preferences, standing context);
+  skills read them from the observation messages (they are in the session).
+- No skill-visible new API needed for Phase 2 of skills; a later `!memory`
+  supervisor command can print the observation log for a conversation.
+
+## 5. Open questions
+
+- [ ] `compactedThrough` as version vs message index (lean version).
+- [ ] Whether provider turns (`.codex()`/`.claude()`) need their own pointer
+  handling — they carry provider-session state and may not accept a shrunken
+  transcript silently; likely exempt them (compaction skips runs suspended
+  inside a provider turn).
+- [ ] Observation-message chunking: one growing summary vs periodic discrete
+  entries (lean discrete entries — append-only, no rewrite of the previous
+  summary, matches Mastra's log shape).
+- [ ] Interaction with `getStructured` backward scan (it scans raw messages —
+  unaffected since nothing is deleted, but document that structured payloads
+  before the pointer still resolve).
+
+## 6. Rejected alternatives
+
+- **Rewrite/squash history** — breaks lineage keys, delta chaining, prompt
+  cache, and the future golden-record replay corpus. Excluded by charter.
+- **Separate observation store collection** — five backends of new ops to
+  hide the summary from the transcript it belongs to.
+- **Compact mid-run** — a session transition outside a node boundary would
+  bypass the checkpoint contract; terminal boundaries only.
+- **RAG/semantic recall now** — commodity, low priority per the roadmap;
+  buildable later as a source/middleware without new core machinery.

--- a/design-docs/object-model.md
+++ b/design-docs/object-model.md
@@ -1,0 +1,170 @@
+# Object model: Agent, Conversation, App, and the Model port
+
+Decision record for the top-level object ontology — what an `Agent` *is*, what
+you `send()` to, where the LLM lives — following the messaging-model.md
+discussion (which fixed the *inside* of a run: inbox noun, receive verb; this
+document fixes the *outside*). No backward-compatibility constraint (pre-1.0).
+
+Legend: `[x]` decided · `[~]` proposed, awaiting review · `[ ]` open.
+
+---
+
+## 0. The framing problem: send to what? bind to what?
+
+Two candidate spellings surfaced in design discussion, each committing to a
+different ontology:
+
+- `agent.send(input)` — the Agent **is** the actor, one mailbox per agent.
+  Natural for a singleton personal agent (claw); breaks the moment one
+  behavior serves many concurrent conversations (which conversation receives
+  it?). Every actor framework resolves this with spawn → handle.
+- `agent.bind(inbox)` — the Agent is a wirable component. This fuses behavior
+  definition with deployment wiring; the same agent can no longer be attached
+  to Discord, Slack, and a test harness without editing it. The binding DSL
+  (binding-routing-dsl.md) deliberately rejected this fusion.
+
+The codebase already has the right three-layer ontology — it just never gave
+the middle layer a noun:
+
+| Concept | What it is | Today's API |
+| --- | --- | --- |
+| `Agent` | **class** — immutable behavior definition (graph + tools) | `Agent.create('support')...` |
+| durable run | **instance** — identity + inbox + session; the actual actor | a bare `runId` string |
+| `PromptTrailApp` | **host** — store, lease, recovery, event→instance routing | `app.send({ runId })` |
+
+`send` has no visible receiver because the instance is spelled as a string
+argument. That absence — not the Agent API — is what makes `agent.send()`
+feel missing.
+
+## 1. Decisions
+
+### [~] 1.1 Reify the instance: the conversation handle
+
+```ts
+const conv = app.conversation('ticket-42', support); // get-or-create handle
+await conv.send('My order never arrived');           // deliver + run to rest
+conv.status;                                          // 'suspended' | 'done' | ...
+await conv.session();                                 // transcript
+await conv.delete();
+```
+
+- Pure sugar over `app.send/resume/delete({ runId })` — zero runtime change;
+  the per-run mutex, lease fencing, and recovery all apply beneath it.
+- The Durable Objects / Akka shape: class → addressed instance → stub.
+- A singleton personal agent is the degenerate case:
+  `const me = app.conversation('main', claw)`.
+- `agent.execute()` survives as the script/ephemeral shortcut, documented as
+  "static convenience on the class", not the model.
+- `[ ]` Noun: `conversation` (chat surfaces, matches the binding DSL's
+  `.conversation(...)` resolver) vs `run` (jobs). Leaning `conversation` with
+  `runId` kept as the underlying identity term.
+
+### [x] 1.2 Binding stays on the host
+
+`app.on(trigger, b => b.to(agent).conversation(...))` is an identity mapping —
+*which conversation does this platform event belong to* — and inherently lives
+above any single conversation. `agent.bind(...)` is rejected (§0).
+
+### [~] 1.3 `Source.llm()` is dissolved into a `Model` port
+
+`Source` today conflates two things: **where content comes from** (cli,
+literal, list, callback — genuine content provision for user/system nodes) and
+**the brain** (model + params + tools + loop policy on `Source.llm()`).
+The brain is not behavior; it is an injected dependency — evidence already in
+the codebase:
+
+- claw's gate injects a mock reply source into `behavior(agent, reply)` and
+  production injects the configured model: behavior fixed, brain swapped.
+- The replay roadmap (B0/B1) serves model calls from a cassette — i.e. the
+  model is an external served through a port, exactly like a tool.
+
+Split:
+
+- **`Model`** — the brain port. Provider factories `Model.openai(...)`,
+  `Model.anthropic(...)`, `Model.google(...)`, `Model.mock([...])`; a spec
+  carries model name + generation params.
+- **`Source`** — remains, for content provision only (`Source.cli()`,
+  `Source.literal()`, `Source.list()`, `Source.callback()`, ...).
+- `Source.llm()` is deleted at the end of the migration (kept internal during
+  it).
+
+### [~] 1.4 Wirable but default: the model cascade
+
+Everyday authoring never names a model:
+
+```ts
+const support = Agent.create('support')
+  .system('Answer support questions.')
+  .tool('searchDocs', searchDocs)
+  .receive()
+  .assistant();                        // bare: default brain, auto tool-loop
+
+const app = PromptTrail.app({
+  model: Model.openai('gpt-5.4-nano', { temperature: 0.2 }),
+  agents: { support },
+});
+```
+
+Four wiring altitudes, resolved specific → general, fail-fast at registration
+when none is bound:
+
+1. **node pin** — `.assistant('summarize', { model: Model.google('gemini-3.1-flash-lite') })`
+   (multi-model graphs are a real use case)
+2. **execute/run option** — `execute({ model: Model.mock(['ok']) })` — tests,
+   the claw gate, evals, replay cassettes
+3. **agent default** — `Agent.create('x', { model: ... })` — the author's
+   recommendation
+4. **app default** — deployment fallback
+
+### [x] 1.5 What moves off the old `Source.llm()`
+
+- **Tools** — already agent capabilities via `.tool()`; `addTool` on the
+  source disappears. Vendor-loop consent is a node option:
+  `.assistant({ toolLoop: 'vendor' })`.
+- **Validation/retry** (`validate`, `maxAttempts`) — behavior semantics; move
+  to node options.
+- `structured` / `goal` consume the same Model cascade.
+
+### [x] 1.6 The delegation spectrum (why `.codex()` stays a node)
+
+LLM access today has two shapes because they differ in *how much agency is
+delegated*, not by accident:
+
+```
+Model (function)            — we own loop, state, checkpoints
+  + toolLoop (ai-sdk)       — we own the loop, tools surface on the session
+  + toolLoop('vendor')      — provider owns the loop inside one turn
+.codex() / .claude()        — provider owns a whole sub-agent turn
+                              (provider session persisted, reconnect on resume)
+```
+
+The model is an injected service; **the degree of delegation is declared at
+the node**. `.codex()`/`.claude()` remain nodes at the far end of the
+spectrum; their transports can later join the app-default cascade.
+
+## 2. The completed mental model
+
+```
+Agent        = class     (prompt structure + tool capabilities)
+Conversation = instance  (identity + inbox + session)  … conv.send() / conv.receive-side is messaging-model.md
+App          = host      (store, lease, recovery, bindings, default Model)
+Model        = port      (node > execute > agent > app)
+```
+
+## 3. Migration (staged with messaging-model.md as one "authoring v2" wave)
+
+1. Introduce `Model` + cascade + bare `.assistant()`; `Source.llm()` becomes
+   an internal adapter.
+2. Migrate README/examples/tests/claw; move tools/validation off sources.
+3. Delete `Source.llm()` (MIGRATION.md one-liners; version gate invalidates
+   old checkpoints once, shared with the receive() wave).
+
+## 4. Open questions
+
+- [ ] Handle noun: `conversation` vs `run` (§1.1).
+- [ ] `Model` spec shape: plain config object vs class with `.with(params)`
+  refinement; how provider-specific options (headers, baseURL) ride it.
+- [ ] Whether per-conversation model override (between execute and agent in
+  the cascade) has a real use case — excluded until one appears.
+- [ ] How the cassette/replay source (B1) presents as a `Model` implementation
+  — align with the B0 recording design when it lands.


### PR DESCRIPTION
Two design records, no code:

**object-model.md** — the outside counterpart to messaging-model.md (#58), from today's design discussion:
- Agent = class, Conversation = reified instance handle (app.conversation(id, agent) → conv.send()), App = host; agent.bind()/agent.send() both rejected with reasons
- Source.llm() dissolves into a **Model port** — 'wirable but default': bare .assistant() + cascade node > execute > agent > app; Model.mock/cassette injection unifies tests, the claw gate, and future replay
- tools/validation move off sources; the .codex()/.claude() delegation spectrum documented
- staged as one 'authoring v2' migration wave together with receive() (#58)

**memory-compaction.md** — claw roadmap #4 prerequisite: append-only observation log (never rewrite history), context-assembly pointer, compaction as a keyed effect at terminal boundaries; storage-side delta-chain snapshot reusing the existing rewrite-delta concept; claw conversation-facts tie-in.

Both awaiting review before implementation, same as #58.