### PR TITLE
refactor: rename the DI channel context → services (state-channels §2.4)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,8 +15,16 @@
 - `durable: true` / `.durable(...)` -> `checkpoint: true | store` /
   `.checkpoint(...)`.
 - Top-level `store` execute option -> `checkpoint: store`.
-- `RuntimeDispatchContext.channelPrompt` is no longer typed; pass custom
-  context keys through the open context record.
+- `RuntimeDispatchServices.channelPrompt` is no longer typed; pass custom
+  keys through the open services record.
+- `context` -> `services`: the run-scoped DI channel (`PromptTrailRunOptions`/
+  `PromptTrailSendOptions.context`, `StoredRun.context`, `BindingDefaults`/
+  `RuntimeBinding.context`, the `.context(...)` binding builder method,
+  `GraphExecutionOptions.context`, `ExecutionRuntimeState.context`,
+  `ToolExecutionContext.context`, and the `context_json` store column) is now
+  named `services` throughout. `ToolExecutionContext`, `ExecutionPhaseContext`,
+  and similar boundary-context types keep their names — only the DI-channel
+  field inside them was renamed.
 - `Agent.execute({ checkpoint })` returns the durable run envelope
   `{ status, runId, session, awaiting? }`; non-checkpoint execute returns
   `Session`.

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ app.on(discord.messages(), (b) =>
     .input((event) => event.content)
     .reply(discord.replyToOriginThread())
     .where(discord.notBot())
-    .context((event) => ({ channel: event.channel })),
+    .services((event) => ({ channel: event.channel })),
 );
 ```
 

--- a/examples/readme_snippets.ts
+++ b/examples/readme_snippets.ts
@@ -238,7 +238,7 @@ app.on(discord.messages(), (b) =>
     .input((event) => event.content)
     .reply(discord.replyToOriginThread())
     .where(discord.notBot())
-    .context((event) => ({ channel: event.channel })),
+    .services((event) => ({ channel: event.channel })),
 );
 
 const bundle = app.bundle();

--- a/packages/core/src/__tests__/unit/ai_sdk_tools.test.ts
+++ b/packages/core/src/__tests__/unit/ai_sdk_tools.test.ts
@@ -82,7 +82,7 @@ describe('ai-sdk tool adapter internals', () => {
     const aiSdkTool = promptTrailToolToAiSdkTool(promptTrailTool, {
       session,
       provider: 'ai-sdk',
-      context: { channel: 'claw-test' },
+      services: { channel: 'claw-test' },
     }) as unknown as {
       execute: (input: unknown, raw: unknown) => Promise<unknown>;
     };
@@ -98,7 +98,7 @@ describe('ai-sdk tool adapter internals', () => {
       {
         session,
         provider: 'ai-sdk',
-        context: { channel: 'claw-test' },
+        services: { channel: 'claw-test' },
         capability: 'search',
         raw: { toolCallId: 'call-1' },
       },

--- a/packages/core/src/__tests__/unit/anthropic_messages.test.ts
+++ b/packages/core/src/__tests__/unit/anthropic_messages.test.ts
@@ -540,7 +540,7 @@ describe('Anthropic Messages native adapter helpers', () => {
       execute: ({ query }, context) => ({
         query,
         provider: context.provider,
-        channel: context.context?.channel,
+        channel: context.services?.channel,
       }),
     });
     const toolUses = collectAnthropicToolUses([

--- a/packages/core/src/__tests__/unit/claude_agent.test.ts
+++ b/packages/core/src/__tests__/unit/claude_agent.test.ts
@@ -30,7 +30,7 @@ describe('Claude Agent SDK adapter helpers', () => {
       execute: ({ query }, context) => ({
         query,
         provider: context.provider,
-        channel: context.context?.channel,
+        channel: context.services?.channel,
       }),
     });
     const definition = promptTrailToolToClaudeAgentToolDefinition(

--- a/packages/core/src/__tests__/unit/codex_app_server.test.ts
+++ b/packages/core/src/__tests__/unit/codex_app_server.test.ts
@@ -493,7 +493,7 @@ describe('Codex App Server helpers', () => {
       execute: ({ query }, context) => ({
         query,
         provider: context.provider,
-        channel: context.context?.channel,
+        channel: context.services?.channel,
       }),
     });
     const handler = createCodexToolRequestHandler(

--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -601,7 +601,7 @@ describe('checkpoint app runtime', () => {
       agent: 'persisted',
       runId: 'run-persist-commits',
       checkpoint: true,
-      context: {
+      services: {
         delivery: {
           platform: 'fake-chat',
           channel: 'C_general',
@@ -1026,7 +1026,7 @@ describe('checkpoint app runtime', () => {
           providerSessions: { ...(live.providerSessions ?? {}) },
           graphCursor: live.graphCursor,
           graphSuspendedAt: live.graphSuspendedAt,
-          context: live.context,
+          services: live.services,
         };
       }
     }

--- a/packages/core/src/__tests__/unit/generate.test.ts
+++ b/packages/core/src/__tests__/unit/generate.test.ts
@@ -248,7 +248,7 @@ describe('streamPromptTrailToolLoop', () => {
       description: 'Lookup docs',
       inputSchema: z.object({ query: z.string() }),
       execute: ({ query }, context) => {
-        toolContexts.push(context.context);
+        toolContexts.push(context.services);
         return { value: `result:${query}` };
       },
     });
@@ -265,7 +265,7 @@ describe('streamPromptTrailToolLoop', () => {
             api: 'responses',
           },
           capabilities: [lookup] as CapabilitySet,
-          context: { channel: 'stream-context' },
+          services: { channel: 'stream-context' },
         },
         {
           provider: 'openai',
@@ -338,7 +338,7 @@ describe('streamPromptTrailToolLoop', () => {
       description: 'Lookup docs',
       inputSchema: z.object({ query: z.string() }),
       execute: ({ query }, context) => {
-        toolContexts.push(context.context);
+        toolContexts.push(context.services);
         return { value: `result:${query}` };
       },
     });
@@ -346,7 +346,7 @@ describe('streamPromptTrailToolLoop', () => {
     const events: string[] = [];
     let seq = 0;
     const runtime = createExecutionRuntimeState({
-      context: { channel: 'runtime-context' },
+      services: { channel: 'runtime-context' },
       middleware: [
         Middleware.create({
           name: 'toolPolicy',

--- a/packages/core/src/__tests__/unit/google_gemini.test.ts
+++ b/packages/core/src/__tests__/unit/google_gemini.test.ts
@@ -649,7 +649,7 @@ describe('Google Gemini native adapter helpers', () => {
       execute: ({ query }, context) => ({
         query,
         provider: context.provider,
-        channel: context.context?.channel,
+        channel: context.services?.channel,
       }),
     });
     const calls = collectGeminiFunctionCalls({

--- a/packages/core/src/__tests__/unit/graph_executor.test.ts
+++ b/packages/core/src/__tests__/unit/graph_executor.test.ts
@@ -140,17 +140,17 @@ describe('GraphExecutor', () => {
     const graph = Agent.create('assistant')
       .conditional(
         'branch',
-        ({ context }) => context?.ready === true,
+        ({ services }) => services?.ready === true,
         (then) => then.assistant('readyReply', 'ready'),
         (otherwise) => otherwise.assistant('notReadyReply', 'not ready'),
       )
       .toGraph();
 
     const thenSession = await executeAgentGraph(graph, {
-      context: { ready: true },
+      services: { ready: true },
     });
     const elseSession = await executeAgentGraph(graph, {
-      context: { ready: false },
+      services: { ready: false },
     });
 
     expect(thenSession.getLastMessage()?.content).toBe('ready');
@@ -383,7 +383,7 @@ describe('GraphExecutor', () => {
       execute: ({ id }, context) => {
         seen.push({
           id,
-          context: context.context,
+          services: context.services,
           effect: context.effect,
           capability: context.capability,
         });
@@ -412,13 +412,13 @@ describe('GraphExecutor', () => {
     });
 
     await executeAgentGraph(graph, {
-      context: { runId: 'graph-run' },
+      services: { runId: 'graph-run' },
     });
 
     expect(seen).toEqual([
       {
         id: '1',
-        context: { runId: 'graph-run' },
+        services: { runId: 'graph-run' },
         effect: { repeatable: true, kind: 'external-read' },
         capability: 'lookup',
       },

--- a/packages/core/src/__tests__/unit/interceptors.test.ts
+++ b/packages/core/src/__tests__/unit/interceptors.test.ts
@@ -117,7 +117,7 @@ describe('execution interceptors', () => {
     await runExecutionPhase({
       phase: 'beforeModel',
       session: createSession(),
-      context: {
+      services: {
         channelPrompt: 'fake-chat channel policy',
         delivery: { platform: 'fake-chat', channelId: 'C1' },
         deliveryBindings: { checkWrite: async () => undefined },
@@ -128,16 +128,16 @@ describe('execution interceptors', () => {
       middleware: [
         Middleware.create({
           name: 'channelPolicy',
-          beforeModel: ({ context }) => {
-            seen.push(context);
+          beforeModel: ({ services }) => {
+            seen.push(services);
           },
         }),
       ],
       hooks: [
         Hook.create({
           name: 'audit',
-          onBeforeModel: ({ context }) => {
-            seen.push(context);
+          onBeforeModel: ({ services }) => {
+            seen.push(services);
           },
         }),
       ],
@@ -156,7 +156,7 @@ describe('execution interceptors', () => {
       phase: 'wrapModelCall',
       session: createSession(),
       request: { prompt: 'original' },
-      context: {
+      services: {
         channelPrompt: 'fake-chat channel policy',
         delivery: { platform: 'fake-chat', channelId: 'C1' },
         deliveryBindings: { checkWrite: async () => undefined },
@@ -167,8 +167,8 @@ describe('execution interceptors', () => {
       middleware: [
         Middleware.create({
           name: 'modelWrapper',
-          wrapModelCall: ({ context }, next) => {
-            seen.push(context);
+          wrapModelCall: ({ services }, next) => {
+            seen.push(services);
             return next();
           },
         }),

--- a/packages/core/src/__tests__/unit/openai_responses.test.ts
+++ b/packages/core/src/__tests__/unit/openai_responses.test.ts
@@ -731,7 +731,7 @@ describe('OpenAI Responses native adapter helpers', () => {
       execute: ({ query }, context) => ({
         query,
         provider: context.provider,
-        channel: context.context?.channel,
+        channel: context.services?.channel,
       }),
     });
     const calls = collectOpenAIResponseFunctionCalls([

--- a/packages/core/src/__tests__/unit/public_api.test.ts
+++ b/packages/core/src/__tests__/unit/public_api.test.ts
@@ -186,7 +186,7 @@ describe('public API surface', () => {
     const options: AgentExecuteOptionsWithCheckpoint = {
       runId: 'public-direct-agent-run',
       checkpoint,
-      context: { userId: 'U1' },
+      services: { userId: 'U1' },
       signal: controller.signal,
       observers: [
         () => {

--- a/packages/core/src/__tests__/unit/runtime_server.test.ts
+++ b/packages/core/src/__tests__/unit/runtime_server.test.ts
@@ -75,12 +75,12 @@ const fakeChat = {
         event: FakeMessageEvent,
         defaults: { behavior?: unknown },
       ) => passesFakeChatBehavior(event, defaults.behavior),
-      resolveContext: ({
+      resolveServices: ({
         defaults,
         event,
       }: {
         defaults: {
-          context?: Record<string, unknown>;
+          services?: Record<string, unknown>;
           skills?: readonly string[];
         };
         event: FakeMessageEvent;
@@ -149,10 +149,10 @@ function passesFakeChatBehavior(
 }
 
 function resolveFakeChatChannelPrompt(
-  defaults: { context?: Record<string, unknown> },
+  defaults: { services?: Record<string, unknown> },
   event: FakeMessageEvent,
 ): string | undefined {
-  const prompts = defaults.context?.channelPrompts as
+  const prompts = defaults.services?.channelPrompts as
     | Record<string, string>
     | undefined;
   if (!prompts) {
@@ -166,10 +166,10 @@ function resolveFakeChatChannelPrompt(
 }
 
 function resolveFakeChatChannelSkills(
-  defaults: { context?: Record<string, unknown>; skills?: readonly string[] },
+  defaults: { services?: Record<string, unknown>; skills?: readonly string[] },
   event: FakeMessageEvent,
 ): readonly string[] | undefined {
-  const bindings = defaults.context?.channelSkillBindings as
+  const bindings = defaults.services?.channelSkillBindings as
     | Array<{ channel: string; skills: readonly string[] }>
     | undefined;
   if (!bindings) {
@@ -250,9 +250,9 @@ describe('RuntimeServer', () => {
       middleware: [
         Middleware.create({
           name: 'mutatingDeliveryContext',
-          beforeModel: ({ context }) => {
+          beforeModel: ({ services }) => {
             const delivery = (
-              context as {
+              services as {
                 delivery?: { channel?: string };
               }
             ).delivery;
@@ -608,7 +608,7 @@ describe('RuntimeServer', () => {
     const app = PromptTrail.app({
       name: 'graph-runtime-app',
       defaults: {
-        context: { appScope: 'runtime-app' },
+        services: { appScope: 'runtime-app' },
         delivery: Delivery.origin() as DeliveryTarget,
       },
     }).on(fakeChat.messages(), (binding) => {
@@ -616,7 +616,7 @@ describe('RuntimeServer', () => {
         .to(main)
         .conversation(() => 'fake-chat:graph')
         .reply(fakeChat.channel('general'))
-        .context((event) => ({
+        .services((event) => ({
           bindingScope: 'fake-chat-message',
           channelId: event.channelId,
         }));
@@ -648,7 +648,7 @@ describe('RuntimeServer', () => {
       fakeChat.channel('general'),
     );
     expect(result.delivery).toEqual(fakeChat.channel('general'));
-    expect(result.context).toEqual(
+    expect(result.services).toEqual(
       expect.objectContaining({
         appScope: 'runtime-app',
         bindingScope: 'fake-chat-message',
@@ -1083,7 +1083,7 @@ describe('RuntimeServer', () => {
       agents: { main },
       defaults: {
         checkpoint: true,
-        context: {
+        services: {
           channelPrompts: {
             general: 'General channel prompt',
           },
@@ -1130,15 +1130,15 @@ describe('RuntimeServer', () => {
         middleware: [
           Middleware.create({
             name: 'channelPrompt',
-            beforeModel: ({ context }) => {
+            beforeModel: ({ services }) => {
               middlewareDelivery.push(
-                (context as { delivery?: unknown } | undefined)?.delivery,
+                (services as { delivery?: unknown } | undefined)?.delivery,
               );
               return {
                 session: {
                   vars: {
                     channelPrompt: (
-                      context as { channelPrompt: string | undefined }
+                      services as { channelPrompt: string | undefined }
                     ).channelPrompt,
                   },
                 },
@@ -1842,7 +1842,7 @@ describe('RuntimeServer', () => {
       event,
       defaults,
     });
-    const delivery = dispatched.context.delivery as
+    const delivery = dispatched.services.delivery as
       | { channel?: string }
       | undefined;
     if (delivery) {

--- a/packages/core/src/__tests__/unit/source/llm_source.test.ts
+++ b/packages/core/src/__tests__/unit/source/llm_source.test.ts
@@ -83,7 +83,7 @@ describe('LlmSource', () => {
   describe('runtime tool loop', () => {
     it('uses generateTextStream when runtime is provided for native tool sources', async () => {
       const runtime = createExecutionRuntimeState({
-        context: { channel: 'runtime' },
+        services: { channel: 'runtime' },
         middleware: [],
       });
       const lookup = Tool.create({

--- a/packages/core/src/__tests__/unit/templates/agent_graph.test.ts
+++ b/packages/core/src/__tests__/unit/templates/agent_graph.test.ts
@@ -1628,12 +1628,12 @@ describe('Agent graph authoring', () => {
     const controller = new AbortController();
     const session = await Agent.create('assistant')
       .assistant('reply', (_session, runtime) => {
-        expect(runtime?.context?.channel).toBe('docs');
+        expect(runtime?.services?.channel).toBe('docs');
         expect(runtime?.signal).toBe(controller.signal);
         return 'ok';
       })
       .execute({
-        context: { channel: 'docs' },
+        services: { channel: 'docs' },
         signal: controller.signal,
       });
 
@@ -1649,14 +1649,14 @@ describe('Agent graph authoring', () => {
         runtime?: ExecutionRuntimeState,
       ): Promise<string> {
         seenSignal = runtime?.signal;
-        return String(runtime?.context?.channel);
+        return String(runtime?.services?.channel);
       }
     })();
 
     const session = await Agent.create('assistant')
       .assistant('reply', source)
       .execute({
-        context: { channel: 'docs' },
+        services: { channel: 'docs' },
         signal: controller.signal,
       });
 

--- a/packages/core/src/__tests__/unit/templates/agent_interceptors.test.ts
+++ b/packages/core/src/__tests__/unit/templates/agent_interceptors.test.ts
@@ -357,17 +357,17 @@ describe('Agent interceptors', () => {
       .use(
         Middleware.create({
           name: 'context',
-          beforeModel: ({ context }) => ({
+          beforeModel: ({ services }) => ({
             session: {
               vars: {
-                channel: context?.channel,
+                channel: services?.channel,
               },
             },
           }),
         }),
       )
       .assistant('reply')
-      .execute({ context: { channel: 'claw-test' } });
+      .execute({ services: { channel: 'claw-test' } });
 
     expect(session.getVarsObject()).toEqual({ channel: 'claw-test' });
   });
@@ -377,17 +377,17 @@ describe('Agent interceptors', () => {
       .use(
         Middleware.create({
           name: 'nestedContext',
-          beforeModel: ({ context }) => ({
+          beforeModel: ({ services }) => ({
             session: {
               vars: {
-                userId: context?.userId,
+                userId: services?.userId,
               },
             },
           }),
         }),
       )
       .assistant('reply')
-      .execute({ context: { userId: 'U1' } });
+      .execute({ services: { userId: 'U1' } });
 
     expect(session.getVarsObject()).toEqual({ userId: 'U1' });
   });

--- a/packages/core/src/__tests__/unit/templates/assistant.test.ts
+++ b/packages/core/src/__tests__/unit/templates/assistant.test.ts
@@ -22,7 +22,7 @@ describe('AssistantTemplate', () => {
 
   it('passes execution runtime to content sources', async () => {
     const runtime = createExecutionRuntimeState({
-      context: { channel: 'assistant-runtime' },
+      services: { channel: 'assistant-runtime' },
       middleware: [],
     });
     class RuntimeAwareSource extends Source<string> {

--- a/packages/core/src/__tests__/unit/templates/claude_turn.test.ts
+++ b/packages/core/src/__tests__/unit/templates/claude_turn.test.ts
@@ -272,16 +272,16 @@ describe('ClaudeTurn template', () => {
     await Agent.create('claude-turn')
       .claude({
         client,
-        sessionId: (_session, context) => `session-${context?.channel}`,
-        input: (session, context) =>
-          `${context?.channel}:${session.getLastMessage()?.content}`,
+        sessionId: (_session, services) => `session-${services?.channel}`,
+        input: (session, services) =>
+          `${services?.channel}:${session.getLastMessage()?.content}`,
       })
       .execute({
         session: Session.create().addMessage({
           type: 'user',
           content: 'hello',
         }),
-        context: { channel: 'claw-test' },
+        services: { channel: 'claw-test' },
       });
 
     expect(client.queries[0].prompt).toBe('claw-test:hello');

--- a/packages/core/src/__tests__/unit/templates/codex_turn.test.ts
+++ b/packages/core/src/__tests__/unit/templates/codex_turn.test.ts
@@ -295,16 +295,16 @@ describe('CodexTurn template', () => {
     await Agent.create('codex-turn')
       .codex({
         client,
-        threadId: (_session, context) => `thread-${context?.channel}`,
-        input: (session, context) =>
-          `${context?.channel}:${session.getLastMessage()?.content}`,
+        threadId: (_session, services) => `thread-${services?.channel}`,
+        input: (session, services) =>
+          `${services?.channel}:${session.getLastMessage()?.content}`,
       })
       .execute({
         session: Session.create().addMessage({
           type: 'user',
           content: 'hello',
         }),
-        context: { channel: 'claw-test' },
+        services: { channel: 'claw-test' },
       });
 
     expect(client.threadStarts).toHaveLength(0);

--- a/packages/core/src/anthropic_messages.ts
+++ b/packages/core/src/anthropic_messages.ts
@@ -171,7 +171,7 @@ export async function generateAnthropicMessagesText<TVars extends Vars>(
           tools,
           session,
           resolvedOptions.approvalHandler,
-          resolvedOptions.context,
+          resolvedOptions.services,
         ),
       ),
     );
@@ -380,7 +380,7 @@ export async function generateAnthropicMessagesWithSchema<TVars extends Vars>(
           tools,
           session,
           resolvedOptions.approvalHandler,
-          resolvedOptions.context,
+          resolvedOptions.services,
         ),
       ),
     );
@@ -968,7 +968,7 @@ export async function createAnthropicToolResultBlock(
   tools: readonly PromptTrailTool[],
   session: Session<any>,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ) {
   const tool = tools.find((candidate) => candidate.name === toolUse.name);
   if (!tool) {
@@ -984,7 +984,7 @@ export async function createAnthropicToolResultBlock(
   // (vendor loop); ctx.idempotencyKey still reaches the tool for remote dedup.
   const result = await executePromptTrailTool(tool, toolUse.input, {
     session,
-    context,
+    services,
     provider: 'anthropic',
     approvalHandler,
     raw: toolUse.raw,

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -31,7 +31,7 @@ export type ApprovalPolicy = 'never' | 'always' | 'on-risk' | ApprovalHandler;
 
 export interface ToolExecutionContext {
   session?: Session<any>;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   provider?: ApprovalRequest['provider'] | 'ai-sdk';
   capability?: string;
   raw?: unknown;

--- a/packages/core/src/claude_agent.ts
+++ b/packages/core/src/claude_agent.ts
@@ -17,7 +17,7 @@ export type ClaudeAgentInput<TVars extends Vars> =
   | string
   | ((
       session: Session<TVars>,
-      context: Record<string, unknown> | undefined,
+      services: Record<string, unknown> | undefined,
     ) => string | Promise<string>);
 
 export type ClaudeAgentSessionId<TVars extends Vars> =
@@ -26,7 +26,7 @@ export type ClaudeAgentSessionId<TVars extends Vars> =
   | 'auto'
   | ((
       session: Session<TVars>,
-      context: Record<string, unknown> | undefined,
+      services: Record<string, unknown> | undefined,
     ) => string | undefined | Promise<string | undefined>);
 
 export interface ClaudeAgentClient {
@@ -172,7 +172,7 @@ export function promptTrailToolToClaudeAgentToolDefinition(
   tool: PromptTrailTool,
   session: Session<any>,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ): ClaudeAgentToolDefinition {
   return {
     name: tool.name,
@@ -181,7 +181,7 @@ export function promptTrailToolToClaudeAgentToolDefinition(
     execute: (input) =>
       executePromptTrailTool(tool, input, {
         session,
-        context,
+        services,
         provider: 'claude-agent',
         capability: tool.name,
         approvalHandler,
@@ -195,14 +195,14 @@ export function createClaudePromptTrailMcpServer(
   sdk?: ClaudeAgentSdkLike,
   serverName = 'prompttrail',
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ): unknown {
   const definitions = tools.map((tool) =>
     promptTrailToolToClaudeAgentToolDefinition(
       tool,
       session,
       approvalHandler,
-      context,
+      services,
     ),
   );
 
@@ -255,7 +255,7 @@ export function getClaudeAgentMcpServers(
   session: Session<any>,
   sdk?: ClaudeAgentSdkLike,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
   const servers: Record<string, unknown> = {};
   for (const server of getClaudeMcpServers(capabilities)) {
@@ -268,7 +268,7 @@ export function getClaudeAgentMcpServers(
       sdk,
       'prompttrail',
       approvalHandler,
-      context,
+      services,
     );
   }
   return Object.keys(servers).length > 0 ? servers : undefined;
@@ -280,7 +280,7 @@ export function buildClaudeAgentQueryParams(
   options: Omit<
     ClaudeTurnOptions,
     'client' | 'input' | 'onEvent' | 'squashWith'
-  > & { context?: Record<string, unknown> },
+  > & { services?: Record<string, unknown> },
   sdk?: ClaudeAgentSdkLike,
 ): ClaudeAgentQueryParams {
   const tools = getClaudePromptTrailTools(options.capabilities);
@@ -291,7 +291,7 @@ export function buildClaudeAgentQueryParams(
     session,
     sdk,
     options.approvalHandler,
-    options.context,
+    options.services,
   );
   const mcpAllowedTools = getClaudeAllowedMcpToolNames(
     getClaudeMcpServers(options.capabilities),

--- a/packages/core/src/codex_app_server.ts
+++ b/packages/core/src/codex_app_server.ts
@@ -29,7 +29,7 @@ export type CodexThreadId =
   | 'auto'
   | ((
       session: Session<any>,
-      context: Record<string, unknown> | undefined,
+      services: Record<string, unknown> | undefined,
     ) => string | undefined | Promise<string | undefined>);
 
 export type CodexTurnInput =
@@ -37,7 +37,7 @@ export type CodexTurnInput =
   | unknown[]
   | ((
       session: Session<any>,
-      context: Record<string, unknown> | undefined,
+      services: Record<string, unknown> | undefined,
     ) => string | unknown[] | Promise<string | unknown[]>);
 
 export interface CodexThreadStartParams {
@@ -1012,7 +1012,7 @@ export function createCodexToolRequestHandler(
   session: Session<any>,
   fallback?: CodexInboundRequestHandler,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ): CodexInboundRequestHandler {
   const byName = new Map(tools.map((tool) => [tool.name, tool]));
 
@@ -1036,7 +1036,7 @@ export function createCodexToolRequestHandler(
 
     return executePromptTrailTool(tool, getCodexToolCallInput(request.params), {
       session,
-      context,
+      services,
       provider: 'codex',
       approvalHandler,
       raw: request.raw,
@@ -1049,7 +1049,7 @@ export function createCodexRuntimeRequestHandler(options: {
   session: Session<any>;
   fallback?: CodexInboundRequestHandler;
   approvalHandler?: ApprovalHandler;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
 }): CodexInboundRequestHandler {
   const toolHandler =
     options.tools && options.tools.length > 0
@@ -1058,7 +1058,7 @@ export function createCodexRuntimeRequestHandler(options: {
           options.session,
           undefined,
           options.approvalHandler,
-          options.context,
+          options.services,
         )
       : undefined;
 

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -169,7 +169,7 @@ export interface StoredRun<TVars extends Vars> {
   timers?: DurableTimer[];
   graphCursor?: number;
   graphSuspendedAt?: string;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
 }
 
 export interface SessionCheckpointDelta<_TVars extends Vars = Vars> {
@@ -195,7 +195,7 @@ export type StoredRunPatch = Partial<
     | 'status'
     | 'graphCursor'
     | 'graphSuspendedAt'
-    | 'context'
+    | 'services'
     | 'agentName'
     | 'graphManifest'
   >
@@ -211,7 +211,7 @@ export interface PromptTrailRunOptions<TVars extends Vars = Vars> {
   session?: Session<TVars>;
   checkpoint?: CheckpointOption;
   resumable?: boolean;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
 }
 
 export interface PromptTrailSendOptions {
@@ -220,7 +220,7 @@ export interface PromptTrailSendOptions {
   input: string | Omit<Inbound, 'offset'>;
   checkpoint?: CheckpointOption;
   resumable?: boolean;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
 }
 
 export interface InboundRuntimeEvent {
@@ -1755,7 +1755,7 @@ export class PromptTrailApp {
     runId: string;
     input?: string | Omit<Inbound, 'offset'>;
     session?: Session<TVars>;
-    context?: Record<string, unknown>;
+    services?: Record<string, unknown>;
   }): Promise<DurableRunResult<TVars>> {
     const existing = await this.store.get(options.runId);
     if (existing) {
@@ -1772,7 +1772,7 @@ export class PromptTrailApp {
         session: options.session,
         input: options.input,
         checkpoint: true,
-        context: options.context,
+        services: options.services,
       });
     }
     if (options.input === undefined) {
@@ -1782,7 +1782,7 @@ export class PromptTrailApp {
       runId: options.runId,
       input: options.input,
       checkpoint: true,
-      context: options.context,
+      services: options.services,
     });
   }
 
@@ -1812,14 +1812,14 @@ export class PromptTrailApp {
         runId: options.runId,
         input: options.input,
         checkpoint,
-        context: options.context,
+        services: options.services,
       });
     }
 
-    if (options.context) {
-      existing.context = cloneDurableRuntimeValue(options.context);
+    if (options.services) {
+      existing.services = cloneDurableRuntimeValue(options.services);
       await this.store.patch(options.runId, {
-        context: existing.context,
+        services: existing.services,
       });
     }
     if (
@@ -2021,7 +2021,7 @@ export class PromptTrailApp {
     runId: string,
     run: StoredRun<TVars>,
   ): Promise<void> {
-    const target = deliveryTargetFromContext(run.context);
+    const target = deliveryTargetFromServices(run.services);
     if (!target || !run.result) {
       return;
     }
@@ -2084,7 +2084,7 @@ export class PromptTrailApp {
         inbox: [],
         providerSessions: {},
         graphCursor: 0,
-        context: cloneDurableRuntimeValue(options.context),
+        services: cloneDurableRuntimeValue(options.services),
       };
       await this.store.create(runId, run);
       this.setPersistedSessionBaseline(runId, run.initial);
@@ -2132,7 +2132,7 @@ export class PromptTrailApp {
           idempotencyKey:
             event.idempotencyKey ?? runEventIdempotencyKey(runId, seq, type),
         },
-        observerContextFromRunContext(options.context),
+        observerContextFromRunServices(options.services),
       );
     };
     await emitGraphRunEvent('run.started', { sessionVersion: 0 });
@@ -2143,7 +2143,7 @@ export class PromptTrailApp {
           options.input === undefined
             ? undefined
             : graphInboundFromAppInput(options.input),
-        context: options.context,
+        services: options.services,
       });
       await emitGraphRunEvent('run.completed', {
         sessionVersion: session.messages.length,
@@ -2216,7 +2216,7 @@ export class PromptTrailApp {
         {
           session: checkpoint.session,
           input: inbox,
-          context: cloneDurableRuntimeValue(run.context),
+          services: cloneDurableRuntimeValue(run.services),
           eventScopeId: runId,
           nextEventSeq: () => this.nextRunEventSeq(runId),
           durableBoundary: () => durableBoundary,
@@ -2316,7 +2316,7 @@ export class PromptTrailApp {
     run: StoredRun<TVars>,
     event: ExecutionEvent,
   ): Promise<void> {
-    const context = observerContextFromRunContext(run.context);
+    const context = observerContextFromRunServices(run.services);
     await this.observerBus.emit(event, context);
     for (const bus of this.observerBuses) {
       await bus.emit(event, context);
@@ -2360,7 +2360,7 @@ export class PromptTrailApp {
       status: run.status,
       graphCursor: run.graphCursor,
       graphSuspendedAt: run.graphSuspendedAt,
-      context: run.context,
+      services: run.services,
       agentName: run.agentName,
       graphManifest: run.graphManifest,
     });
@@ -2481,10 +2481,10 @@ function firedTimerIds(run: StoredRun<any>): ReadonlySet<string> {
   return ids;
 }
 
-function deliveryTargetFromContext(
-  context: Record<string, unknown> | undefined,
+function deliveryTargetFromServices(
+  services: Record<string, unknown> | undefined,
 ): DeliveryTarget | undefined {
-  const delivery = context?.delivery;
+  const delivery = services?.delivery;
   if (
     delivery &&
     typeof delivery === 'object' &&
@@ -2496,12 +2496,12 @@ function deliveryTargetFromContext(
   return undefined;
 }
 
-function observerContextFromRunContext(
-  context: Record<string, unknown> | undefined,
+function observerContextFromRunServices(
+  services: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
   return {
-    runContext: cloneDurableRuntimeValue(context),
-    delivery: cloneDurableRuntimeValue(deliveryTargetFromContext(context)),
+    runServices: cloneDurableRuntimeValue(services),
+    delivery: cloneDurableRuntimeValue(deliveryTargetFromServices(services)),
   };
 }
 

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -279,7 +279,7 @@ export async function generateText<TVars extends Vars>(
     topK: options.topK,
     tools: toAiSdkToolSet(options.tools, {
       session,
-      context: options.context,
+      services: options.services,
       approvalHandler: options.approvalHandler,
     }),
     toolChoice: options.toolChoice,
@@ -550,7 +550,7 @@ export async function* generateTextStream<TVars extends Vars>(
     topK: options.topK,
     tools: toAiSdkToolSet(options.tools, {
       session,
-      context: options.context,
+      services: options.services,
       approvalHandler: options.approvalHandler,
     }),
     toolChoice: options.toolChoice,
@@ -629,7 +629,7 @@ export async function* streamPromptTrailToolLoop(
           tools: getPromptTrailToolList(options),
           session: nextSession,
           approvalHandler: options.approvalHandler,
-          context: config.runtime.context,
+          services: config.runtime.services,
           runtime: config.runtime,
         });
         yield executed.message as Message;
@@ -643,7 +643,7 @@ export async function* streamPromptTrailToolLoop(
             tools: getPromptTrailToolList(options),
             session: currentSession,
             approvalHandler: options.approvalHandler,
-            context: options.context,
+            services: options.services,
           }),
         ),
       );
@@ -663,7 +663,7 @@ async function executeStreamingToolCallWithRuntime(
     tools: readonly PromptTrailTool[];
     session: Session<any>;
     approvalHandler?: LLMOptions['approvalHandler'];
-    context?: Record<string, unknown>;
+    services?: Record<string, unknown>;
     runtime: ExecutionRuntimeState<any>;
   },
 ): Promise<{ message: Message; session: Session<any> }> {
@@ -727,7 +727,7 @@ async function executeStreamingToolCallWithRuntime(
           tools: options.tools,
           session,
           approvalHandler: options.approvalHandler,
-          context: options.context,
+          services: options.services,
         }) as Promise<Message>;
       },
     });
@@ -767,14 +767,14 @@ async function executeStreamingToolCall(
     tools: readonly PromptTrailTool[];
     session: Session<any>;
     approvalHandler?: LLMOptions['approvalHandler'];
-    context?: Record<string, unknown>;
+    services?: Record<string, unknown>;
   },
 ): Promise<Message> {
   const tool = options.tools.find((candidate) => candidate.name === call.name);
   const result = tool
     ? await executePromptTrailTool(tool, call.arguments, {
         session: options.session,
-        context: options.context,
+        services: options.services,
         provider: options.provider,
         capability: call.name,
         approvalHandler: options.approvalHandler,

--- a/packages/core/src/google_gemini.ts
+++ b/packages/core/src/google_gemini.ts
@@ -209,7 +209,7 @@ async function generateGoogleGeminiMessage<TVars extends Vars>(
           tools,
           session,
           options.approvalHandler,
-          options.context,
+          options.services,
         ),
       ),
     );
@@ -1006,7 +1006,7 @@ export async function createGeminiFunctionResponsePart(
   tools: readonly PromptTrailTool[],
   session: Session<any>,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ) {
   const tool = tools.find((candidate) => candidate.name === call.name);
   // Native Gemini tools run outside any durable boundary by design
@@ -1014,7 +1014,7 @@ export async function createGeminiFunctionResponsePart(
   const result: CallToolResult = tool
     ? await executePromptTrailTool(tool, call.args, {
         session,
-        context,
+        services,
         provider: 'google',
         approvalHandler,
         raw: call.raw,

--- a/packages/core/src/graph_executor.ts
+++ b/packages/core/src/graph_executor.ts
@@ -45,7 +45,7 @@ import type { IValidator } from './validators';
 export interface GraphExecutionOptions<TVars extends Vars = Vars> {
   session?: Session<TVars>;
   input?: string | GraphInboundInput | readonly GraphInboundInput[];
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
   maxLoopIterations?: number;
   observers?: readonly ObserverLike[];
@@ -142,7 +142,7 @@ interface GraphExecutionState<TVars extends Vars> {
   inbox: GraphInboundInput[];
   cursor: number;
   maxLoopIterations: number;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
   runtime: ExecutionRuntimeState<TVars>;
   skipNode?: GraphExecutionOptions<TVars>['skipNode'];
@@ -190,12 +190,12 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
   let eventSeq = 0;
   const nextEventSeq =
     options.nextEventSeq ?? options.runtime?.nextEventSeq ?? (() => eventSeq++);
-  const context = options.context ?? options.runtime?.context;
+  const services = options.services ?? options.runtime?.services;
   const signal = options.signal ?? options.runtime?.signal;
   const emitEvent = (event: ExecutionEvent) =>
     Promise.resolve(options.runtime?.emitEvent?.(event)).then(() =>
       observerBus.emit(event, {
-        ...context,
+        ...services,
         signal,
       }),
     );
@@ -207,7 +207,7 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
     : createExecutionRuntimeState<TVars>({
         middleware: graph.middleware,
         hooks: graph.hooks,
-        context,
+        services,
         signal,
         emitEvent,
         eventScopeId,
@@ -217,7 +217,7 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
         recordProviderSession: options.recordProviderSession,
       });
   if (options.runtime) {
-    runtime.context = context;
+    runtime.services = services;
     runtime.signal = signal;
     runtime.emitEvent = emitEvent;
     runtime.eventScopeId = eventScopeId;
@@ -235,7 +235,7 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
     inbox: normalizeGraphInbox(options.input),
     cursor: 0,
     maxLoopIterations: options.maxLoopIterations ?? 10,
-    context,
+    services,
     signal,
     runtime,
     skipNode: options.skipNode,
@@ -974,7 +974,7 @@ async function executeEffectTransformNode<TVars extends Vars>(
     const boundary = durable ?? directExecutionBoundary;
     const callHandler = async () => {
       return handler(state.session, {
-        context: state.context,
+        services: state.services,
         signal: state.signal,
         once: boundary.once.bind(boundary),
         idempotencyKey,
@@ -1135,7 +1135,7 @@ async function resolveGraphAssistantInput<TVars extends Vars>(
 ): Promise<string | ModelOutput> {
   if (typeof input === 'function') {
     const result = await input(session, {
-      context: state.context,
+      services: state.services,
       signal: state.signal,
     });
     if (typeof result === 'string' || isModelOutput(result)) {
@@ -1173,7 +1173,7 @@ function executeGoalSatisfactionNode<TVars extends Vars>(
       session: state.session,
       goal: goal.goal,
       attempt: goal.attempt,
-      context: state.context,
+      services: state.services,
       signal: state.signal,
     });
     if (isThenable(result)) {
@@ -1301,7 +1301,7 @@ async function executeToolsNode<TVars extends Vars>(
         const executeTool = (durable?: ExecutionDurableBoundary) =>
           executePromptTrailTool(tool, request.arguments, {
             session,
-            context: state.context,
+            services: state.services,
             raw: request,
             capability: request.name,
             effect: isExecutionEffectDeclaration(toolEffect)
@@ -1475,12 +1475,12 @@ function graphConditionContext<TVars extends Vars>(
   state: GraphExecutionState<TVars>,
 ): {
   session: Session<TVars>;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
 } {
   return Object.assign(Object.create(state.session), {
     session: state.session,
-    context: state.context,
+    services: state.services,
     signal: state.signal,
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,7 +165,7 @@ export type {
   RuntimeBindingLike,
   RuntimeBundle,
   RuntimeBundleOptions,
-  RuntimeContextResolver,
+  RuntimeServicesResolver,
   RuntimeDeliveryTarget,
   RuntimeFilter,
   Trigger,

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -77,7 +77,7 @@ export interface ExecutionPhaseContext<
   session: Session<TVars>;
   request?: TRequest;
   result?: TResult;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   middlewareState: Record<string, unknown>;
   durable: ExecutionDurableBoundary;
   once: ExecutionDurableBoundary['once'];
@@ -211,7 +211,7 @@ export interface RunExecutionPhaseOptions<
   session: Session<TVars>;
   request?: TRequest;
   result?: TResult;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   middlewareState?: Record<string, unknown>;
   middleware?: readonly MiddlewareDefinition<TVars>[];
   hooks?: readonly HookDefinition<TVars>[];
@@ -255,7 +255,7 @@ export interface RunMiddlewareWrapperOptions<
     session: Session<TVars>;
     request: TRequest;
   }) => Promise<TResult>;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   middlewareState?: Record<string, unknown>;
   middleware?: readonly MiddlewareDefinition<TVars>[];
   beforeVersion?: number;
@@ -284,7 +284,7 @@ export interface ExecutionRuntimeState<TVars extends Vars = Vars> {
   middlewareState: Record<string, unknown>;
   durableBoundary?: ExecutionDurableBoundaryProvider;
   version: number;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
   emitEvent?: (event: ExecutionEvent) => Promise<void> | void;
   nextEventSeq?: () => number;
@@ -301,7 +301,7 @@ export function createExecutionRuntimeState<
 >(options?: {
   middleware?: readonly MiddlewareDefinition<TVars>[];
   hooks?: readonly HookDefinition<TVars>[];
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   durableBoundary?: ExecutionDurableBoundaryProvider;
   signal?: AbortSignal;
   emitEvent?: (event: ExecutionEvent) => Promise<void> | void;
@@ -319,7 +319,7 @@ export function createExecutionRuntimeState<
     middlewareState: {},
     durableBoundary: options?.durableBoundary,
     version: 0,
-    context: options?.context,
+    services: options?.services,
     signal: options?.signal,
     emitEvent: options?.emitEvent,
     nextEventSeq: options?.nextEventSeq,
@@ -364,7 +364,7 @@ export async function runRuntimeExecutionPhase<
     session: options.session,
     request: options.request,
     result: options.result,
-    context: runtime.context,
+    services: runtime.services,
     middlewareState: runtime.middlewareState,
     middleware: options.middleware ?? runtime.middleware,
     hooks: options.hooks ?? runtime.hooks,
@@ -400,7 +400,7 @@ export async function runRuntimeMiddlewareWrapper<
     session: options.session,
     request: options.request,
     call: options.call,
-    context: runtime.context,
+    services: runtime.services,
     middlewareState: runtime.middlewareState,
     middleware: options.middleware ?? runtime.middleware,
     beforeVersion: runtime.version,
@@ -483,7 +483,7 @@ export async function runExecutionPhase<
   let version = options.beforeVersion ?? 0;
   let command: ResolvedExecutionCommand = { type: 'none' };
   const steps: ExecutionPhaseStep[] = [];
-  const handlerContext = sanitizeExecutionHandlerContext(options.context);
+  const handlerServices = sanitizeExecutionHandlerServices(options.services);
 
   for (const [registrationIndex, middleware] of (
     options.middleware ?? []
@@ -509,7 +509,7 @@ export async function runExecutionPhase<
       session,
       request,
       result,
-      context: handlerContext,
+      services: handlerServices,
       middlewareState,
       durable,
       once: durable.once.bind(durable),
@@ -574,7 +574,7 @@ export async function runExecutionPhase<
       session,
       request,
       result,
-      context: handlerContext,
+      services: handlerServices,
       middlewareState,
       durable,
       once: durable.once.bind(durable),
@@ -637,7 +637,7 @@ export async function runMiddlewareWrapper<
   let command: ResolvedExecutionCommand = { type: 'none' };
   const steps: ExecutionPhaseStep[] = [];
   const middleware = options.middleware ?? [];
-  const handlerContext = sanitizeExecutionHandlerContext(options.context);
+  const handlerServices = sanitizeExecutionHandlerServices(options.services);
 
   const invoke = async (
     index: number,
@@ -703,7 +703,7 @@ export async function runMiddlewareWrapper<
       phase: options.phase,
       session,
       request,
-      context: handlerContext,
+      services: handlerServices,
       middlewareState,
       durable,
       once: durable.once.bind(durable),
@@ -782,11 +782,11 @@ export async function runMiddlewareWrapper<
   };
 }
 
-function sanitizeExecutionHandlerContext(
-  context: Record<string, unknown> | undefined,
+function sanitizeExecutionHandlerServices(
+  services: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
-  if (!context || !hasSideEffectingContextHandle(context)) {
-    return context;
+  if (!services || !hasSideEffectingServiceHandle(services)) {
+    return services;
   }
   const {
     delivery: _delivery,
@@ -795,19 +795,19 @@ function sanitizeExecutionHandlerContext(
     platformBinding: _platformBinding,
     platformBindings: _platformBindings,
     ...rest
-  } = context;
+  } = services;
   return rest;
 }
 
-function hasSideEffectingContextHandle(
-  context: Record<string, unknown>,
+function hasSideEffectingServiceHandle(
+  services: Record<string, unknown>,
 ): boolean {
   return (
-    'delivery' in context ||
-    'deliveryBindings' in context ||
-    'observerDeliveryBindings' in context ||
-    'platformBinding' in context ||
-    'platformBindings' in context
+    'delivery' in services ||
+    'deliveryBindings' in services ||
+    'observerDeliveryBindings' in services ||
+    'platformBinding' in services ||
+    'platformBindings' in services
   );
 }
 

--- a/packages/core/src/llm_types.ts
+++ b/packages/core/src/llm_types.ts
@@ -71,7 +71,7 @@ export interface LLMOptions {
   conversationBinding?: 'off' | 'auto';
   skillInjection?: 'warn' | 'error' | 'silent';
   approvalHandler?: ApprovalHandler;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   thinking?: ThinkingOptions;
   cacheKey?: string;
   cacheRetention?: 'in_memory' | '24h';

--- a/packages/core/src/openai_responses.ts
+++ b/packages/core/src/openai_responses.ts
@@ -209,7 +209,7 @@ async function generateOpenAIResponsesMessage<TVars extends Vars>(
           tools,
           session,
           requestOptions.approvalHandler,
-          requestOptions.context,
+          requestOptions.services,
         ),
       ),
     );
@@ -722,7 +722,7 @@ export async function createOpenAIToolOutputItem(
   tools: readonly PromptTrailTool[],
   session: Session<any>,
   approvalHandler?: ApprovalHandler,
-  context?: Record<string, unknown>,
+  services?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   const tool = tools.find((candidate) => candidate.name === call.name);
   if (!tool) {
@@ -740,7 +740,7 @@ export async function createOpenAIToolOutputItem(
   // (vendor loop); ctx.idempotencyKey still reaches the tool for remote dedup.
   const result = await executePromptTrailTool(tool, call.arguments, {
     session,
-    context,
+    services,
     provider: 'openai',
     approvalHandler,
     raw: call.raw,

--- a/packages/core/src/runtime_bindings.ts
+++ b/packages/core/src/runtime_bindings.ts
@@ -17,7 +17,7 @@ export type InputResolver<TEvent extends TriggerEvent> =
   | string
   | ((event: TEvent & Record<string, unknown>) => string);
 
-export type RuntimeContextResolver<TEvent extends TriggerEvent> =
+export type RuntimeServicesResolver<TEvent extends TriggerEvent> =
   | Record<string, unknown>
   | ((event: TEvent & Record<string, unknown>) => Record<string, unknown>);
 
@@ -38,7 +38,7 @@ export interface BindingDefaults {
   toolsets?: readonly string[];
   skills?: readonly string[];
   workdir?: string;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   behavior?: unknown;
 }
 
@@ -50,7 +50,7 @@ export interface Trigger<TEvent extends TriggerEvent = TriggerEvent> {
     delivery: DeliveryTarget,
     event: TEvent,
   ) => DeliveryTarget | undefined;
-  resolveContext?: (options: {
+  resolveServices?: (options: {
     conversationId: string;
     defaults: BindingDefaults;
     delivery: DeliveryTarget | undefined;
@@ -65,7 +65,7 @@ export interface RuntimeBinding<TEvent extends TriggerEvent> {
   agent: string;
   conversation: ConversationResolver<TEvent>;
   input?: InputResolver<TEvent>;
-  context?: RuntimeContextResolver<TEvent>;
+  services?: RuntimeServicesResolver<TEvent>;
   defaults: BindingDefaults;
   name?: string;
 }
@@ -96,7 +96,7 @@ export class BindingBuilder<TEvent extends TriggerEvent> {
   private agentRef?: RuntimeAgentRef;
   private conversationResolver?: ConversationResolver<TEvent>;
   private inputResolver?: InputResolver<TEvent>;
-  private contextResolver?: RuntimeContextResolver<TEvent>;
+  private servicesResolver?: RuntimeServicesResolver<TEvent>;
   private bindingDefaults: BindingDefaults = {};
   private bindingName?: string;
 
@@ -167,8 +167,8 @@ export class BindingBuilder<TEvent extends TriggerEvent> {
     return this;
   }
 
-  context(context: RuntimeContextResolver<TEvent>): this {
-    this.contextResolver = context;
+  services(services: RuntimeServicesResolver<TEvent>): this {
+    this.servicesResolver = services;
     return this;
   }
 
@@ -205,7 +205,7 @@ export class BindingBuilder<TEvent extends TriggerEvent> {
       agent: this.agentName,
       conversation: this.conversationResolver,
       input: this.inputResolver,
-      context: this.contextResolver,
+      services: this.servicesResolver,
       defaults: { ...this.bindingDefaults },
       name: this.bindingName,
     };

--- a/packages/core/src/runtime_dispatch.ts
+++ b/packages/core/src/runtime_dispatch.ts
@@ -12,7 +12,7 @@ import { assistantDeliveryKey } from './runtime_delivery_keys';
 
 export { assistantDeliveryKey };
 
-export interface RuntimeDispatchContext extends Record<string, unknown> {
+export interface RuntimeDispatchServices extends Record<string, unknown> {
   conversationId: string;
   delivery?: DeliveryTarget;
   toolsets?: readonly string[];
@@ -35,7 +35,7 @@ export interface RuntimeDispatchOptions<TEvent extends TriggerEvent> {
 export interface RuntimeDispatchResult<TVars extends Vars = Vars> {
   conversationId: string;
   delivery: DeliveryTarget | undefined;
-  context: RuntimeDispatchContext;
+  services: RuntimeDispatchServices;
   content: string;
   result: DurableRunResult<TVars>;
 }
@@ -68,7 +68,7 @@ export function mergeBindingDefaults(
   return {
     ...base,
     ...override,
-    context: { ...(base.context ?? {}), ...(override.context ?? {}) },
+    services: { ...(base.services ?? {}), ...(override.services ?? {}) },
     behavior: { ...(base.behavior ?? {}), ...(override.behavior ?? {}) },
   };
 }
@@ -89,16 +89,16 @@ export function resolveRuntimeInput<TEvent extends TriggerEvent>(
   return binding.trigger.defaultInput?.(event) ?? '';
 }
 
-export function resolveRuntimeBindingContext<TEvent extends TriggerEvent>(
+export function resolveRuntimeBindingServices<TEvent extends TriggerEvent>(
   binding: RuntimeBinding<TEvent>,
   event: TEvent,
 ): Record<string, unknown> | undefined {
-  if (!binding.context) {
+  if (!binding.services) {
     return undefined;
   }
-  return typeof binding.context === 'function'
-    ? binding.context(event as TEvent & Record<string, unknown>)
-    : binding.context;
+  return typeof binding.services === 'function'
+    ? binding.services(event as TEvent & Record<string, unknown>)
+    : binding.services;
 }
 
 export function resolveRuntimeDelivery(
@@ -115,20 +115,20 @@ export function resolveRuntimeDelivery(
   return delivery;
 }
 
-export function runtimeContextFromDefaults(
+export function runtimeServicesFromDefaults(
   conversationId: string,
   defaults: BindingDefaults,
   delivery: DeliveryTarget | undefined,
   _event: TriggerEvent,
-): RuntimeDispatchContext {
+): RuntimeDispatchServices {
   return {
-    ...(defaults.context ?? {}),
+    ...(defaults.services ?? {}),
     conversationId,
     delivery,
     toolsets: defaults.toolsets,
     skills: defaults.skills,
     workdir: defaults.workdir,
-    historyBackfill: defaults.context?.historyBackfill,
+    historyBackfill: defaults.services?.historyBackfill,
   };
 }
 
@@ -139,34 +139,34 @@ export async function dispatchRuntimeEvent<
   options: RuntimeDispatchOptions<TEvent>,
 ): Promise<RuntimeDispatchResult<TVars>> {
   const conversationId = options.binding.conversation(options.event);
-  const bindingContext = resolveRuntimeBindingContext(
+  const bindingServices = resolveRuntimeBindingServices(
     options.binding,
     options.event,
   );
-  const defaults = bindingContext
-    ? mergeBindingDefaults(options.defaults, { context: bindingContext })
+  const defaults = bindingServices
+    ? mergeBindingDefaults(options.defaults, { services: bindingServices })
     : options.defaults;
   const resolvedDelivery = resolveRuntimeDelivery(
     defaults.delivery,
     options.binding as RuntimeBinding<TriggerEvent>,
     options.event,
   );
-  const contextDelivery = cloneRuntimeDispatchValue(resolvedDelivery);
+  const servicesDelivery = cloneRuntimeDispatchValue(resolvedDelivery);
   const delivery = cloneRuntimeDispatchValue(resolvedDelivery);
-  const context = runtimeContextFromDefaults(
+  const services = runtimeServicesFromDefaults(
     conversationId,
     defaults,
-    contextDelivery,
+    servicesDelivery,
     options.event,
   );
-  const triggerContext = options.binding.trigger.resolveContext?.({
+  const triggerServices = options.binding.trigger.resolveServices?.({
     conversationId,
     defaults,
-    delivery: contextDelivery,
+    delivery: servicesDelivery,
     event: options.event,
   });
-  if (triggerContext) {
-    Object.assign(context, triggerContext);
+  if (triggerServices) {
+    Object.assign(services, triggerServices);
   }
   const content =
     options.content ?? resolveRuntimeInput(options.binding, options.event);
@@ -181,18 +181,18 @@ export async function dispatchRuntimeEvent<
         ...runtimeEventAttrs(options.event),
         ...(options.binding.trigger.eventAttrs?.(options.event) ?? {}),
         ...(options.attrs ?? {}),
-        runtimeContext: context,
+        runtimeServices: services,
       },
     },
     checkpoint: options.checkpoint ?? defaults.checkpoint ?? true,
     resumable: options.resumable,
-    context,
+    services,
   });
 
   return {
     conversationId,
     delivery,
-    context,
+    services,
     content,
     result,
   };

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -200,7 +200,7 @@ function llmGenerationManifestDescriptor(options: LLMOptions) {
     approvalHandler: options.approvalHandler
       ? { present: true, name: options.approvalHandler.name || undefined }
       : undefined,
-    context: options.context ? { present: true } : undefined,
+    services: options.services ? { present: true } : undefined,
   };
 }
 

--- a/packages/core/src/templates/agent.ts
+++ b/packages/core/src/templates/agent.ts
@@ -73,7 +73,7 @@ type AgentGraphStructuredFold<
 > = (obj: z.infer<TSchema>, session: Session<TC>) => Session<any>;
 
 export interface AgentGraphTransformEffectContext {
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
   once: ExecutionDurableBoundary['once'];
   idempotencyKey?: string;
@@ -89,7 +89,7 @@ type AgentGraphEffectTransformHandler<TC extends Vars> = (
 ) => Session<TC> | Promise<Session<TC>>;
 
 export interface AgentGraphHandlerRuntime {
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
 }
 
@@ -97,7 +97,7 @@ export type AgentGraphCondition<TC extends Vars = Vars> =
   | boolean
   | ((context: {
       session: Session<TC>;
-      context?: Record<string, unknown>;
+      services?: Record<string, unknown>;
       signal?: AbortSignal;
     }) => boolean);
 
@@ -109,7 +109,7 @@ export interface AgentGoalSatisfactionContext<TC extends Vars = Vars> {
   session: Session<TC>;
   goal: string;
   attempt: number;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
 }
 
@@ -1122,7 +1122,7 @@ export class Agent<TC extends Vars = Vars> {
       }
       return executeAgentGraph(this.toLegacyExecutionGraph(), {
         session,
-        context: executionOptions?.context,
+        services: executionOptions?.services,
         signal: executionOptions?.signal,
         observers: executionOptions?.observers,
         observerDeliveryBindings: executionOptions?.observerDeliveryBindings,
@@ -1152,7 +1152,7 @@ export class Agent<TC extends Vars = Vars> {
         parentRuntime ??
         (executionOptions
           ? createExecutionRuntimeState<TC>({
-              context: executionOptions.context,
+              services: executionOptions.services,
               eventScopeId,
               signal: executionOptions.signal,
             })
@@ -1165,7 +1165,7 @@ export class Agent<TC extends Vars = Vars> {
     return executeAgentGraph(this.toLegacyExecutionGraph(), {
       session,
       runtime: parentRuntime,
-      context: executionOptions?.context,
+      services: executionOptions?.services,
       signal: executionOptions?.signal,
       observers: executionOptions?.observers,
       observerDeliveryBindings: executionOptions?.observerDeliveryBindings,
@@ -1260,7 +1260,7 @@ export class Agent<TC extends Vars = Vars> {
       runId: durableOptions.runId,
       session: executionOptions?.session,
       input: input === undefined ? undefined : graphInputForDurableSend(input),
-      context: executionOptions?.context,
+      services: executionOptions?.services,
     });
     return durableOptions.returnEnvelope ? result : result.session;
   }
@@ -1286,7 +1286,7 @@ export class Agent<TC extends Vars = Vars> {
 
 export interface AgentExecutionOptions {
   runId?: string;
-  context?: Record<string, unknown>;
+  services?: Record<string, unknown>;
   signal?: AbortSignal;
   checkpoint?: AgentCheckpointOption;
   observers?: readonly ObserverLike[];
@@ -1552,7 +1552,7 @@ function wrapLegacyCondition<TC extends Vars>(
 ):
   | ((context: {
       session: Session<TC>;
-      context?: Record<string, unknown>;
+      services?: Record<string, unknown>;
       signal?: AbortSignal;
     }) => boolean)
   | undefined {

--- a/packages/core/src/templates/primitives/claude_turn.ts
+++ b/packages/core/src/templates/primitives/claude_turn.ts
@@ -83,7 +83,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
         phase: 'prepareModelInput',
         session: currentSession,
         request: { session: modelSession },
-        context: runtime.context,
+        services: runtime.services,
         middlewareState: runtime.middlewareState,
         middleware: runtime.middleware,
         hooks: runtime.hooks,
@@ -121,7 +121,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
       const client =
         this.options.client ?? (await createDefaultClaudeAgentClient());
       const prompt = prependClaudeRestartNotice(
-        await this.resolveInput(request.session, runtime?.context),
+        await this.resolveInput(request.session, runtime?.services),
         request.restartNotice,
       );
       const checkpointBinding = request.ignoreCheckpointBinding
@@ -129,7 +129,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
         : this.resolveCheckpointBinding(runtime, options.nodePath);
       const sessionId = checkpointBinding
         ? checkpointBinding.id
-        : await this.resolveSessionId(request.session, runtime?.context);
+        : await this.resolveSessionId(request.session, runtime?.services);
       const restarts = request.restarts ?? checkpointBinding?.restarts ?? 0;
       if (sessionId) {
         await this.recordProviderSession(runtime, options.nodePath, {
@@ -153,7 +153,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
         retainMessages: this.options.retainMessages,
         attrsKey: this.options.attrsKey,
         sdkOptions: this.options.sdkOptions,
-        context: runtime?.context,
+        services: runtime?.services,
       });
       if (await emitTurnModelEvent(runtime, 'model.started', 'claudeTurn')) {
         openModelEvents++;
@@ -249,14 +249,14 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
 
   private async resolveInput(
     session: Session<TVars>,
-    context: Record<string, unknown> | undefined,
+    services: Record<string, unknown> | undefined,
   ): Promise<string> {
     if (this.options.input === undefined) {
       return session.getLastMessage()?.content ?? '';
     }
 
     if (typeof this.options.input === 'function') {
-      return this.options.input(session, context);
+      return this.options.input(session, services);
     }
 
     return this.options.input;
@@ -264,7 +264,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
 
   private async resolveSessionId(
     session: Session<TVars>,
-    context: Record<string, unknown> | undefined,
+    services: Record<string, unknown> | undefined,
   ): Promise<string | undefined> {
     if (
       this.options.sessionId === undefined ||
@@ -276,7 +276,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
       return deriveConversationBinding(session, 'claude-agent')?.id;
     }
     if (typeof this.options.sessionId === 'function') {
-      return this.options.sessionId(session, context);
+      return this.options.sessionId(session, services);
     }
 
     return this.options.sessionId;

--- a/packages/core/src/templates/primitives/codex_turn.ts
+++ b/packages/core/src/templates/primitives/codex_turn.ts
@@ -106,7 +106,7 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
             session: currentSession,
             fallback: this.options.onRequest,
             approvalHandler: this.options.approvalHandler,
-            context: runtime?.context,
+            services: runtime?.services,
           })
         : this.options.onRequest;
     let modelSession = currentSession;
@@ -115,7 +115,7 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
         phase: 'prepareModelInput',
         session: currentSession,
         request: { session: modelSession },
-        context: runtime.context,
+        services: runtime.services,
         middlewareState: runtime.middlewareState,
         middleware: runtime.middleware,
         hooks: runtime.hooks,
@@ -183,10 +183,10 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
           : this.resolveCheckpointBinding(runtime, options.nodePath);
         const resolvedThreadId = checkpointBinding
           ? checkpointBinding.id
-          : await this.resolveThreadId(request.session, runtime?.context);
+          : await this.resolveThreadId(request.session, runtime?.services);
         const input = await this.resolveInput(
           request.session,
-          runtime?.context,
+          runtime?.services,
         );
         const inputWithRestartNotice =
           request.restartNotice === undefined
@@ -315,7 +315,7 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
 
   private async resolveThreadId(
     session: Session<TVars>,
-    context: Record<string, unknown> | undefined,
+    services: Record<string, unknown> | undefined,
   ): Promise<string | undefined> {
     if (
       this.options.threadId === undefined ||
@@ -328,7 +328,7 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
     }
 
     if (typeof this.options.threadId === 'function') {
-      return this.options.threadId(session, context);
+      return this.options.threadId(session, services);
     }
 
     return this.options.threadId;
@@ -427,14 +427,14 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
 
   private async resolveInput(
     session: Session<TVars>,
-    context: Record<string, unknown> | undefined,
+    services: Record<string, unknown> | undefined,
   ): Promise<string | unknown[] | undefined> {
     if (this.options.input === undefined) {
       return session.getLastMessage()?.content;
     }
 
     if (typeof this.options.input === 'function') {
-      return this.options.input(session, context);
+      return this.options.input(session, services);
     }
 
     return this.options.input;

--- a/packages/core/src/templates/primitives/model_runtime.ts
+++ b/packages/core/src/templates/primitives/model_runtime.ts
@@ -33,7 +33,7 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
     phase: 'prepareModelInput',
     session: validSession,
     request,
-    context: runtime.context,
+    services: runtime.services,
     middlewareState: runtime.middlewareState,
     middleware: runtime.middleware,
     hooks: runtime.hooks,

--- a/packages/discord/src/__tests__/unit/runtime_bindings_mock.test.ts
+++ b/packages/discord/src/__tests__/unit/runtime_bindings_mock.test.ts
@@ -50,7 +50,7 @@ function workroomFixture() {
           'delegation',
         ])
         .defaults({
-          context: {
+          services: {
             historyBackfill: { enabled: true, limit: 50 },
           },
         })
@@ -220,7 +220,7 @@ function channelContextFixture() {
         )
         .defaults({
           delivery: discord.replyToOriginThread(),
-          context: {
+          services: {
             channelPrompts: {
               'cloud-lab': 'Infrastructure debug mode.',
               T_special: 'Incident commander mode.',

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -86,7 +86,7 @@ export const discord = {
         }
         return delivery;
       },
-      resolveContext: ({ defaults, event }) => ({
+      resolveServices: ({ defaults, event }) => ({
         channelPrompt: resolveChannelPrompt(defaults, event),
         skills: resolveChannelSkills(defaults, event),
       }),
@@ -604,7 +604,7 @@ function resolveChannelPrompt(
   defaults: BindingDefaults,
   event: DiscordMessageEvent,
 ): string | undefined {
-  const prompts = defaults.context?.channelPrompts as
+  const prompts = defaults.services?.channelPrompts as
     | Record<string, string>
     | undefined;
   if (!prompts) {
@@ -621,7 +621,7 @@ function resolveChannelSkills(
   defaults: BindingDefaults,
   event: DiscordMessageEvent,
 ): readonly string[] | undefined {
-  const bindings = defaults.context?.channelSkillBindings as
+  const bindings = defaults.services?.channelSkillBindings as
     | Array<{ channel: string; skills: readonly string[] }>
     | undefined;
   if (!bindings) {

--- a/packages/discord/src/testing.ts
+++ b/packages/discord/src/testing.ts
@@ -71,7 +71,7 @@ export interface MockAssistantInput {
   input: {
     latestText: string;
   };
-  context: Record<string, unknown>;
+  services: Record<string, unknown>;
 }
 
 export type MockAssistantHandler = (input: MockAssistantInput) =>
@@ -172,17 +172,17 @@ export function mockDiscord(options: MockDiscordOptions): MockDiscordConnector {
 }
 
 export function deterministicAssistant(): MockAssistantHandler {
-  return ({ input, context }) => ({
+  return ({ input, services }) => ({
     content: `reply:${input.latestText}`,
     attrs: {
       observed: {
-        conversationId: context.conversationId,
-        delivery: context.delivery,
-        toolsets: context.toolsets,
-        skills: context.skills,
-        workdir: context.workdir,
-        historyBackfill: context.historyBackfill,
-        channelPrompt: context.channelPrompt,
+        conversationId: services.conversationId,
+        delivery: services.delivery,
+        toolsets: services.toolsets,
+        skills: services.skills,
+        workdir: services.workdir,
+        historyBackfill: services.historyBackfill,
+        channelPrompt: services.channelPrompt,
       },
     },
   });
@@ -266,7 +266,7 @@ class MockRuntimeFixture {
           const last = session.getLastMessage();
           return assistant({
             input: { latestText: last?.content ?? '' },
-            context: runtime?.context ?? {},
+            services: runtime?.services ?? {},
           });
         });
     }
@@ -369,8 +369,8 @@ class MockRuntimeFixture {
     conversationId: string,
     messages: readonly Message[],
   ): Promise<void> {
-    const runContext =
-      ((await this.store.get(conversationId))?.context as
+    const runServices =
+      ((await this.store.get(conversationId))?.services as
         | Record<string, unknown>
         | undefined) ?? {};
     const pending = messages
@@ -381,7 +381,7 @@ class MockRuntimeFixture {
       .map((message, index) => {
         const attrs = (message.attrs ?? {}) as Record<string, unknown>;
         const observed = (attrs.observed ?? {}) as Record<string, unknown>;
-        const delivery = (observed.delivery ?? runContext.delivery) as
+        const delivery = (observed.delivery ?? runServices.delivery) as
           | DeliveryTarget
           | undefined;
         return {
@@ -443,7 +443,7 @@ class MockRuntimeFixture {
       for (const message of [...messages].reverse()) {
         if (message.type === 'assistant') {
           const attrs = (message.attrs ?? {}) as Record<string, unknown>;
-          return attrs.observed ?? run.context;
+          return attrs.observed ?? run.services;
         }
       }
     }

--- a/packages/store-common/src/index.ts
+++ b/packages/store-common/src/index.ts
@@ -104,7 +104,7 @@ export interface ReconstructStoredRunInput {
   status: StoredRun<any>['status'];
   graphCursor?: number;
   graphSuspendedAt?: string;
-  context?: unknown;
+  services?: unknown;
   /** The initial session in its `Session.toJSON()` form. */
   initialSession: unknown;
   graphManifest?: unknown;
@@ -148,7 +148,7 @@ export function reconstructStoredRun(
     providerSessions: {},
     graphCursor: input.graphCursor,
     graphSuspendedAt: input.graphSuspendedAt,
-    context: input.context as StoredRun<any>['context'],
+    services: input.services as StoredRun<any>['services'],
   };
 
   for (const delta of input.deltas) {

--- a/packages/store-conformance/src/index.ts
+++ b/packages/store-conformance/src/index.ts
@@ -320,7 +320,7 @@ export function runDurableRunStoreConformance(spec: ConformanceSpec): void {
       expect(retrieved!.providerSessions!['main/node0']).toEqual(binding);
     });
 
-    // Case 9: patch updates status/graphCursor/graphSuspendedAt/context/graphManifest
+    // Case 9: patch updates status/graphCursor/graphSuspendedAt/services/graphManifest
     it('case 9: patch updates run fields', async () => {
       await openStore();
       const agentName = Object.keys(agents)[0];
@@ -332,14 +332,14 @@ export function runDurableRunStoreConformance(spec: ConformanceSpec): void {
         status: 'done',
         graphCursor: 5,
         graphSuspendedAt: 'node/waiting',
-        context: { userId: 'u1' },
+        services: { userId: 'u1' },
       });
 
       const retrieved = await store.get(runId);
       expect(retrieved!.status).toBe('done');
       expect(retrieved!.graphCursor).toBe(5);
       expect(retrieved!.graphSuspendedAt).toBe('node/waiting');
-      expect(retrieved!.context).toEqual({ userId: 'u1' });
+      expect(retrieved!.services).toEqual({ userId: 'u1' });
     });
 
     // Case 10: delete removes the run

--- a/packages/store-libsql/src/index.ts
+++ b/packages/store-libsql/src/index.ts
@@ -285,7 +285,7 @@ export class LibsqlRunStore implements DurableRunStore {
         status,
         graph_cursor,
         graph_suspended_at,
-        context_json,
+        services_json,
         initial_session_json,
         graph_manifest_json
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -295,7 +295,7 @@ export class LibsqlRunStore implements DurableRunStore {
         run.status,
         run.graphCursor ?? null,
         run.graphSuspendedAt ?? null,
-        jsonOrNull(run.context),
+        jsonOrNull(run.services),
         JSON.stringify(run.initial.toJSON()),
         jsonOrNull(run.graphManifest),
       ],
@@ -311,7 +311,7 @@ export class LibsqlRunStore implements DurableRunStore {
     // Read current values so we can fill in unpatched fields.
     const res = await this.client.execute({
       sql: `SELECT agent_name, status, graph_cursor, graph_suspended_at,
-                   context_json, graph_manifest_json
+                   services_json, graph_manifest_json
             FROM runs WHERE run_id = ?`,
       args: [runId],
     });
@@ -324,7 +324,7 @@ export class LibsqlRunStore implements DurableRunStore {
       status: row[1] as string,
       graph_cursor: row[2] as number | null,
       graph_suspended_at: row[3] as string | null,
-      context_json: row[4] as string | null,
+      services_json: row[4] as string | null,
       graph_manifest_json: row[5] as string | null,
     };
 
@@ -334,7 +334,7 @@ export class LibsqlRunStore implements DurableRunStore {
               status = ?,
               graph_cursor = ?,
               graph_suspended_at = ?,
-              context_json = ?,
+              services_json = ?,
               graph_manifest_json = ?
             WHERE run_id = ?`,
       args: [
@@ -348,7 +348,9 @@ export class LibsqlRunStore implements DurableRunStore {
         'graphSuspendedAt' in patch
           ? (patch.graphSuspendedAt ?? null)
           : current.graph_suspended_at,
-        'context' in patch ? jsonOrNull(patch.context) : current.context_json,
+        'services' in patch
+          ? jsonOrNull(patch.services)
+          : current.services_json,
         'graphManifest' in patch
           ? jsonOrNull(patch.graphManifest)
           : current.graph_manifest_json,
@@ -523,7 +525,7 @@ export class LibsqlRunStore implements DurableRunStore {
         status TEXT NOT NULL,
         graph_cursor INTEGER,
         graph_suspended_at TEXT,
-        context_json TEXT,
+        services_json TEXT,
         initial_session_json TEXT NOT NULL,
         graph_manifest_json TEXT
       );
@@ -608,7 +610,7 @@ export class LibsqlRunStore implements DurableRunStore {
     // 1. Load the run row.
     const runRes = await this.client.execute({
       sql: `SELECT run_id, agent_name, status, graph_cursor, graph_suspended_at,
-                   context_json, initial_session_json, graph_manifest_json
+                   services_json, initial_session_json, graph_manifest_json
             FROM runs WHERE run_id = ?`,
       args: [runId],
     });
@@ -622,7 +624,7 @@ export class LibsqlRunStore implements DurableRunStore {
       status: r[2] as StoredRun<any>['status'],
       graph_cursor: r[3] as number | null,
       graph_suspended_at: r[4] as string | null,
-      context_json: r[5] as string | null,
+      services_json: r[5] as string | null,
       initial_session_json: r[6] as string,
       graph_manifest_json: r[7] as string | null,
     };
@@ -724,7 +726,7 @@ export class LibsqlRunStore implements DurableRunStore {
         status: row.status,
         graphCursor: row.graph_cursor ?? undefined,
         graphSuspendedAt: row.graph_suspended_at ?? undefined,
-        context: parseJson(row.context_json),
+        services: parseJson(row.services_json),
         initialSession: parseJsonRequired(row.initial_session_json),
         graphManifest: parseJson(row.graph_manifest_json),
         deltas,

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -343,7 +343,7 @@ export class PostgresRunStore implements DurableRunStore {
           status,
           graph_cursor,
           graph_suspended_at,
-          context_json,
+          services_json,
           initial_session_json,
           graph_manifest_json
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
@@ -353,7 +353,7 @@ export class PostgresRunStore implements DurableRunStore {
           run.status,
           run.graphCursor ?? null,
           run.graphSuspendedAt ?? null,
-          jsonOrNull(run.context),
+          jsonOrNull(run.services),
           JSON.stringify(run.initial.toJSON()),
           jsonOrNull(run.graphManifest),
         ],
@@ -373,7 +373,7 @@ export class PostgresRunStore implements DurableRunStore {
     try {
       // Read current run to merge patch (we need current values for missing patch fields)
       const res = await client.query(
-        `SELECT agent_name, status, graph_cursor, graph_suspended_at, context_json, graph_manifest_json
+        `SELECT agent_name, status, graph_cursor, graph_suspended_at, services_json, graph_manifest_json
          FROM runs WHERE run_id = $1`,
         [runId],
       );
@@ -385,7 +385,7 @@ export class PostgresRunStore implements DurableRunStore {
         status: string;
         graph_cursor: number | null;
         graph_suspended_at: string | null;
-        context_json: string | null;
+        services_json: string | null;
         graph_manifest_json: string | null;
       };
 
@@ -395,7 +395,7 @@ export class PostgresRunStore implements DurableRunStore {
           status = $2,
           graph_cursor = $3,
           graph_suspended_at = $4,
-          context_json = $5,
+          services_json = $5,
           graph_manifest_json = $6
         WHERE run_id = $7`,
         [
@@ -409,7 +409,9 @@ export class PostgresRunStore implements DurableRunStore {
           'graphSuspendedAt' in patch
             ? (patch.graphSuspendedAt ?? null)
             : current.graph_suspended_at,
-          'context' in patch ? jsonOrNull(patch.context) : current.context_json,
+          'services' in patch
+            ? jsonOrNull(patch.services)
+            : current.services_json,
           'graphManifest' in patch
             ? jsonOrNull(patch.graphManifest)
             : current.graph_manifest_json,
@@ -658,7 +660,7 @@ export class PostgresRunStore implements DurableRunStore {
           status TEXT NOT NULL,
           graph_cursor INTEGER,
           graph_suspended_at TEXT,
-          context_json TEXT,
+          services_json TEXT,
           initial_session_json TEXT NOT NULL,
           graph_manifest_json TEXT
         )`,
@@ -744,7 +746,7 @@ export class PostgresRunStore implements DurableRunStore {
     // 1. Load the run row
     const runRes = await client.query(
       `SELECT run_id, agent_name, status, graph_cursor, graph_suspended_at,
-              context_json, initial_session_json, graph_manifest_json
+              services_json, initial_session_json, graph_manifest_json
        FROM runs WHERE run_id = $1`,
       [runId],
     );
@@ -757,7 +759,7 @@ export class PostgresRunStore implements DurableRunStore {
       status: StoredRun<any>['status'];
       graph_cursor: number | null;
       graph_suspended_at: string | null;
-      context_json: string | null;
+      services_json: string | null;
       initial_session_json: string;
       graph_manifest_json: string | null;
     };
@@ -893,7 +895,7 @@ export class PostgresRunStore implements DurableRunStore {
         status: row.status,
         graphCursor: row.graph_cursor ?? undefined,
         graphSuspendedAt: row.graph_suspended_at ?? undefined,
-        context: parseJson(row.context_json),
+        services: parseJson(row.services_json),
         initialSession: parseJsonRequired(row.initial_session_json),
         graphManifest: parseJson(row.graph_manifest_json),
         deltas,

--- a/packages/store-redis/src/index.ts
+++ b/packages/store-redis/src/index.ts
@@ -37,7 +37,7 @@ interface RunDocument {
   status: StoredRun<any>['status'];
   graphCursor?: number;
   graphSuspendedAt?: string;
-  context?: unknown;
+  services?: unknown;
   /** Session.toJSON() snapshot captured at run creation. */
   initialSession: unknown;
   graphManifest?: unknown;
@@ -355,7 +355,7 @@ export class RedisRunStore implements DurableRunStore {
       status: run.status,
       graphCursor: run.graphCursor,
       graphSuspendedAt: run.graphSuspendedAt,
-      context: run.context,
+      services: run.services,
       initialSession: run.initial.toJSON(),
       graphManifest: run.graphManifest,
       deltas: [],
@@ -393,8 +393,8 @@ export class RedisRunStore implements DurableRunStore {
     if ('graphSuspendedAt' in patch) {
       doc.graphSuspendedAt = patch.graphSuspendedAt ?? undefined;
     }
-    if ('context' in patch) {
-      doc.context = patch.context;
+    if ('services' in patch) {
+      doc.services = patch.services;
     }
     if ('graphManifest' in patch) {
       doc.graphManifest = patch.graphManifest;
@@ -571,7 +571,7 @@ export class RedisRunStore implements DurableRunStore {
         status: doc.status,
         graphCursor: doc.graphCursor,
         graphSuspendedAt: doc.graphSuspendedAt,
-        context: doc.context,
+        services: doc.services,
         initialSession: doc.initialSession,
         graphManifest: doc.graphManifest,
         deltas,

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -207,7 +207,7 @@ interface RunRow {
   status: StoredRun<any>['status'];
   graph_cursor: number | null;
   graph_suspended_at: string | null;
-  context_json: string | null;
+  services_json: string | null;
   initial_session_json: string;
   graph_manifest_json: string | null;
 }
@@ -304,7 +304,7 @@ export class SqliteRunStore implements DurableRunStore {
         status,
         graph_cursor,
         graph_suspended_at,
-        context_json,
+        services_json,
         initial_session_json,
         graph_manifest_json
       )
@@ -317,7 +317,7 @@ export class SqliteRunStore implements DurableRunStore {
         status = ?,
         graph_cursor = ?,
         graph_suspended_at = ?,
-        context_json = ?,
+        services_json = ?,
         graph_manifest_json = ?
       WHERE run_id = ?
     `);
@@ -409,7 +409,7 @@ export class SqliteRunStore implements DurableRunStore {
       run.status,
       run.graphCursor ?? null,
       run.graphSuspendedAt ?? null,
-      jsonOrNull(run.context),
+      jsonOrNull(run.services),
       JSON.stringify(run.initial.toJSON()),
       jsonOrNull(run.graphManifest),
     );
@@ -437,7 +437,7 @@ export class SqliteRunStore implements DurableRunStore {
       run.status,
       run.graphCursor ?? null,
       run.graphSuspendedAt ?? null,
-      jsonOrNull(run.context),
+      jsonOrNull(run.services),
       jsonOrNull(run.graphManifest),
       runId,
     );
@@ -648,7 +648,7 @@ export class SqliteRunStore implements DurableRunStore {
         status TEXT NOT NULL,
         graph_cursor INTEGER,
         graph_suspended_at TEXT,
-        context_json TEXT,
+        services_json TEXT,
         initial_session_json TEXT NOT NULL,
         graph_manifest_json TEXT
       );
@@ -810,7 +810,7 @@ export class SqliteRunStore implements DurableRunStore {
           status: row.status,
           graphCursor: row.graph_cursor ?? undefined,
           graphSuspendedAt: row.graph_suspended_at ?? undefined,
-          context: parseJson(row.context_json),
+          services: parseJson(row.services_json),
           initialSession: parseJsonRequired(row.initial_session_json),
           graphManifest: parseJson(row.graph_manifest_json),
           deltas,
@@ -922,8 +922,8 @@ function patchSummary(patch: StoredRunPatch): string {
   if ('agentName' in patch) {
     assignments.push(`agent_name=${patch.agentName ?? 'null'}`);
   }
-  if ('context' in patch) {
-    assignments.push('context_json');
+  if ('services' in patch) {
+    assignments.push('services_json');
   }
   if ('graphManifest' in patch) {
     assignments.push('graph_manifest_json');


### PR DESCRIPTION
The run-scoped DI channel is now `services`, renamed through — public options, StoredRun field, binding slot, internals, and the store schema (services_json in sqlite/postgres/libsql, doc field in redis) — so no public-vs-internal naming gap remains. Deliberately NOT renamed: ToolExecutionContext, transform ctx, gateway/dispatch context types — removing that collision is the point of the change. Design docs keep their historical wording.

No compat shims (pre-1.0). MIGRATION.md one-liner added.

Verified: core 757 unit tests, stores 50/25/25/25, discord 16, cron 10, claw 36, typecheck/build/prettier green; grep audit shows zero DI-channel 'context' remnants.