### PR TITLE
feat: B0 recording layer — storage half

### DIFF
--- a/packages/core/src/__tests__/unit/durable.test.ts
+++ b/packages/core/src/__tests__/unit/durable.test.ts
@@ -20,6 +20,7 @@ import type {
   DurableTimer,
   Inbound,
   OnceScope,
+  RunRecordEntry,
   SessionCheckpointDelta,
   StoredRun,
   StoredRunPatch,
@@ -172,6 +173,10 @@ class TrackingRunStore implements DurableRunStore {
     upsertTimer(this.runs.get(runId), timer);
   }
 
+  async appendRecord(runId: string, entry: RunRecordEntry): Promise<void> {
+    appendRecord(this.runs.get(runId), entry);
+  }
+
   async delete(runId: string): Promise<void> {
     this.runs.delete(runId);
   }
@@ -302,6 +307,15 @@ class ControlledDelayRunStore implements DurableRunStore {
     return this.delayWrite('upsertTimer', runId, run, () => {});
   }
 
+  appendRecord(runId: string, entry: RunRecordEntry): Promise<void> {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return Promise.resolve();
+    }
+    appendRecord(run, entry);
+    return this.delayWrite('appendRecord', runId, run, () => {});
+  }
+
   async delete(runId: string): Promise<void> {
     this.runs.delete(runId);
   }
@@ -372,6 +386,7 @@ type RecordedWrite =
       binding: ProviderSessionBinding;
     }
   | { type: 'upsertTimer'; runId: string }
+  | { type: 'appendRecord'; runId: string }
   | { type: 'delete'; runId: string };
 
 class RecordingRunStore implements DurableRunStore {
@@ -491,6 +506,15 @@ class RecordingRunStore implements DurableRunStore {
     }
     upsertTimer(run, timer);
     this.writes.push({ type: 'upsertTimer', runId });
+  }
+
+  async appendRecord(runId: string, entry: RunRecordEntry): Promise<void> {
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    appendRecord(run, entry);
+    this.writes.push({ type: 'appendRecord', runId });
   }
 
   async delete(runId: string): Promise<void> {
@@ -2061,5 +2085,18 @@ function upsertTimer(
     timers[index] = timer;
   } else {
     timers.push(timer);
+  }
+}
+
+function appendRecord(
+  run: StoredRun<any> | undefined,
+  entry: RunRecordEntry,
+): void {
+  if (!run) {
+    return;
+  }
+  const recording = (run.recording ??= []);
+  if (!recording.some((existing) => existing.record.seq === entry.record.seq)) {
+    recording.push(entry);
   }
 }

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -105,6 +105,102 @@ export interface DurableTimer {
   firedAt?: number;
 }
 
+/**
+ * Recording verbosity for the B0 replay layer (design-docs
+ * replay-and-self-deploy.md, Appendix B0). Per agent/run, default `off`:
+ *
+ * - `off` — no recording captured.
+ * - `decisions` — node breadcrumbs + tool calls (name/argsDigest/result) +
+ *   model `requestDigest`/response. Cheap; powers the deterministic diff
+ *   dimensions (routing / control-flow / tool-args / structured).
+ * - `full` — additionally captures the normalized model request bytes and the
+ *   parsed tool input, needed for `request-hash` keying and faithful replay.
+ *   Larger and sensitive (this is the privacy surface).
+ */
+export type RecordLevel = 'off' | 'decisions' | 'full';
+
+/**
+ * A node-enter breadcrumb emitted by the graph executor (design B0 work item
+ * 3). One entry per node entry, so loop/goalAttempts iterations that re-run
+ * under the SAME `nodePath` appear as repeated breadcrumbs distinguished by
+ * `seq` — the record stream is seq-ordered, NOT a `nodePath → record` map.
+ * `branch` names the child a conditional entered. Parallel emits no per-branch
+ * breadcrumbs (its branches run sequentially and are reconstructed from
+ * model/tool record order).
+ */
+export interface NodeBreadcrumb {
+  /** Monotonic per-run sequence number, assigned by the caller. */
+  seq: number;
+  nodePath: string;
+  nodeType: string;
+  branch?: string;
+  /** When the node was entered, epoch milliseconds. */
+  at: number;
+}
+
+/**
+ * A single model/provider call captured at the `wrapModelCall` boundary. The
+ * `requestDigest` is computed from the NORMALIZED request at record time — per
+ * provider (assistant vs Codex vs Claude use different normalizers), so
+ * `provider` is load-bearing for keying. `request` is only populated at the
+ * `full` record level.
+ */
+export interface ModelCallRecord {
+  /** Monotonic per-run sequence number, assigned by the caller. */
+  seq: number;
+  nodePath: string;
+  callIndex: number;
+  /** Provider identity, e.g. 'assistant' | 'codex' | 'claude' | ... */
+  provider: string;
+  /** Hash of the normalized request computed AT RECORD TIME. */
+  requestDigest: string;
+  /** NormalizedModelRequest; captured only at the `full` level. */
+  request?: unknown;
+  /** ModelOutput-shaped response; opaque to the store. */
+  response: unknown;
+  /** When the call was recorded, epoch milliseconds. */
+  at: number;
+}
+
+/**
+ * A single PromptTrail/ai-sdk tool call captured at the `executePromptTrailTool`
+ * funnel. `input` is only populated at the `full` record level. builtin/MCP
+ * tool calls do NOT flow through here — they ride the model/provider response.
+ */
+export interface ToolCallRecord {
+  /** Monotonic per-run sequence number, assigned by the caller. */
+  seq: number;
+  nodePath: string;
+  callIndex: number;
+  toolName: string;
+  /** Hash of the parsed tool arguments computed AT RECORD TIME. */
+  argsDigest: string;
+  /** Parsed tool input; captured only at the `full` level. */
+  input?: unknown;
+  /** CallToolResult-shaped result; opaque to the store. */
+  result: unknown;
+  /** Declared effect metadata, if any. */
+  effect?: unknown;
+  /** When the call was recorded, epoch milliseconds. */
+  at: number;
+}
+
+/**
+ * One entry in a run's seq-ordered recording stream. A run has a SINGLE
+ * append-only sequence of these — `seq` is assigned by the caller monotonically
+ * per run, and the store preserves order and enforces idempotency by
+ * `(runId, seq)` (same discipline as `appendInbox` offsets).
+ */
+export type RunRecordEntry =
+  | { kind: 'node'; record: NodeBreadcrumb }
+  | { kind: 'model'; record: ModelCallRecord }
+  | { kind: 'tool'; record: ToolCallRecord };
+
+/** The seq a record entry carries, regardless of kind. */
+export function runRecordEntrySeq(entry: RunRecordEntry): number {
+  return entry.record.seq;
+}
+
 export interface DurableRunResult<TVars extends Vars = Vars> {
   status: 'done' | 'suspended';
   runId: string;
@@ -167,6 +263,17 @@ export interface StoredRun<TVars extends Vars> {
   inbox: Inbound[];
   providerSessions?: Record<string, ProviderSessionBinding>;
   timers?: DurableTimer[];
+  /**
+   * Seq-ordered recording stream for the B0 replay layer. Append-only,
+   * populated by the (future) capture wiring; absent when nothing was recorded.
+   */
+  recording?: RunRecordEntry[];
+  /**
+   * Recording verbosity for this run, fixed at create time from the app's
+   * `recording` option (default `off`). Placed on the run — not derived
+   * globally — so claw can sample `full` for a fraction of runs later.
+   */
+  recordLevel?: RecordLevel;
   graphCursor?: number;
   graphSuspendedAt?: string;
   services?: Record<string, unknown>;
@@ -551,6 +658,19 @@ export interface DurableRunStore {
     timer: DurableTimer,
     fence?: number,
   ): Promise<void>;
+  /**
+   * Append one entry to the run's seq-ordered recording stream (design B0).
+   * Append-only and idempotent by `(runId, entry.record.seq)`: a second append
+   * with a seq already present is a no-op (first write wins), mirroring
+   * `appendInbox`'s offset idempotency. The store preserves append order; the
+   * caller assigns `seq` monotonically per run. Records are included in
+   * `get`/`entries` reconstruction and removed by `delete`'s cascade.
+   */
+  appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void>;
   delete(runId: string, fence?: number): Promise<void>;
 }
 
@@ -705,6 +825,25 @@ export class MemoryRunStore implements DurableRunStore {
     } else {
       timers.push(timer);
     }
+  }
+
+  async appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    const recording = (run.recording ??= []);
+    const seq = runRecordEntrySeq(entry);
+    // Idempotent by (runId, seq): first write wins, like appendInbox offsets.
+    if (recording.some((existing) => runRecordEntrySeq(existing) === seq)) {
+      return;
+    }
+    recording.push(entry);
   }
 
   async delete(runId: string, fence?: number): Promise<void> {
@@ -916,6 +1055,16 @@ class FencedRunStore implements DurableRunStore {
     );
   }
 
+  appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    return this.guard(() =>
+      this.inner.appendRecord(runId, entry, fence ?? this.fence()),
+    );
+  }
+
   delete(runId: string, fence?: number): Promise<void> {
     return this.guard(() => this.inner.delete(runId, fence ?? this.fence()));
   }
@@ -973,6 +1122,14 @@ export interface PromptTrailAppOptions {
    */
   recovery?: RecoveryOptions | true;
   /**
+   * Recording verbosity for the B0 replay layer, applied to every run this app
+   * creates (design-docs replay-and-self-deploy.md, Appendix B0). Defaults to
+   * `off`. Stored per-run at create time as `StoredRun.recordLevel`, so a later
+   * sampling policy can vary it. This option only wires the level through
+   * create/reconstruction; execution-time capture is a separate follow-up.
+   */
+  recording?: RecordLevel;
+  /**
    * Injectable clock (epoch ms) for the durable-timer sweep (durability roadmap
    * §3). Defaults to `Date.now`. Tests fake it (e.g. vitest fake timers) so
    * timer wake-ups can be driven without sleeping; production leaves it default.
@@ -1021,6 +1178,8 @@ export class PromptTrailApp {
     onError: (runId: string, error: unknown) => void;
   };
   private recoveryTimer?: ReturnType<typeof setInterval>;
+  /** Recording verbosity stamped onto every run this app creates. */
+  private readonly recordLevel: RecordLevel;
   private readonly now: () => number;
   private readonly onTimerError: (
     runId: string,
@@ -1112,6 +1271,7 @@ export class PromptTrailApp {
             )),
       };
     }
+    this.recordLevel = options.recording ?? 'off';
     this.now = options.now ?? Date.now;
     this.onTimerError =
       options.onTimerError ??
@@ -2083,6 +2243,7 @@ export class PromptTrailApp {
         outbox: [],
         inbox: [],
         providerSessions: {},
+        recordLevel: this.recordLevel,
         graphCursor: 0,
         services: cloneDurableRuntimeValue(options.services),
       };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,8 @@ export type {
   InboundKind,
   InboundRuntimeEvent,
   MemoryRunStoreOptions,
+  ModelCallRecord,
+  NodeBreadcrumb,
   OnceBoundary,
   OnceOptions,
   OnceScope,
@@ -54,12 +56,15 @@ export type {
   PromptTrailRegisteredAgent,
   PromptTrailRunOptions,
   PromptTrailSendOptions,
+  RecordLevel,
+  RunRecordEntry,
   RunStore,
   RunStoreLease,
   RunStoreLeaseState,
   SessionCheckpointDelta,
   StoredRun,
   StoredRunPatch,
+  ToolCallRecord,
 } from './durable';
 export { parseDuration } from './duration';
 export { DELETE_VALUE, Observer } from './execution';

--- a/packages/store-common/src/index.ts
+++ b/packages/store-common/src/index.ts
@@ -7,6 +7,8 @@ import {
   type Message,
   type OnceScope,
   type ProviderSessionBinding,
+  type RecordLevel,
+  type RunRecordEntry,
   type SessionCheckpointDelta,
   type StoredRun,
   type Vars,
@@ -116,6 +118,10 @@ export interface ReconstructStoredRunInput {
   providerSessions: Record<string, ProviderSessionBinding>;
   /** Parsed durable timers, if the backend stores any. */
   timers?: DurableTimer[];
+  /** Parsed recording stream (seq order), if the backend stores any. */
+  records?: RunRecordEntry[];
+  /** Recording verbosity persisted on the run, if any. */
+  recordLevel?: RecordLevel;
 }
 
 /**
@@ -171,6 +177,14 @@ export function reconstructStoredRun(
 
   if (input.timers && input.timers.length > 0) {
     run.timers = input.timers.map((timer) => ({ ...timer }));
+  }
+
+  if (input.records && input.records.length > 0) {
+    run.recording = input.records.map((entry) => ({ ...entry }));
+  }
+
+  if (input.recordLevel !== undefined) {
+    run.recordLevel = input.recordLevel;
   }
 
   return run;

--- a/packages/store-conformance/src/index.ts
+++ b/packages/store-conformance/src/index.ts
@@ -9,6 +9,8 @@ import {
   type Inbound,
   type AssistantDeliveryOutboxEntry,
   type DurableTimer,
+  type RecordLevel,
+  type RunRecordEntry,
 } from '@prompttrail/core';
 
 /**
@@ -961,6 +963,175 @@ export function runDurableRunStoreConformance(spec: ConformanceSpec): void {
       await store.create(runId, makeInitialRun(agent, agentName));
       const reconstructed = await store.get(runId);
       expect(reconstructed!.timers ?? []).toHaveLength(0);
+    });
+
+    // -----------------------------------------------------------------------
+    // Recording layer cases (design-docs replay-and-self-deploy.md, B0)
+    // -----------------------------------------------------------------------
+
+    // Case 26: appendRecord round-trips a seq-ordered stream, preserving order
+    // across the three entry kinds (node breadcrumb, model call, tool call).
+    it('case 26: appendRecord round-trips ordered stream across kinds', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-record-26';
+      await store.create(runId, makeInitialRun(agent, agentName));
+
+      const node: RunRecordEntry = {
+        kind: 'node',
+        record: { seq: 0, nodePath: 'main', nodeType: 'scope', at: 100 },
+      };
+      const model: RunRecordEntry = {
+        kind: 'model',
+        record: {
+          seq: 1,
+          nodePath: 'main/assistant',
+          callIndex: 0,
+          provider: 'assistant',
+          requestDigest: 'req-digest-1',
+          response: { text: 'hello' },
+          at: 101,
+        },
+      };
+      const tool: RunRecordEntry = {
+        kind: 'tool',
+        record: {
+          seq: 2,
+          nodePath: 'main/tools',
+          callIndex: 0,
+          toolName: 'search',
+          argsDigest: 'args-digest-1',
+          result: { ok: true },
+          at: 102,
+        },
+      };
+      await store.appendRecord(runId, node);
+      await store.appendRecord(runId, model);
+      await store.appendRecord(runId, tool);
+
+      const retrieved = await store.get(runId);
+      const recording = retrieved!.recording ?? [];
+      expect(recording).toHaveLength(3);
+      expect(recording.map((e) => e.record.seq)).toEqual([0, 1, 2]);
+      expect(recording.map((e) => e.kind)).toEqual(['node', 'model', 'tool']);
+      expect(recording[1]).toEqual(model);
+      expect(recording[2]).toEqual(tool);
+    });
+
+    // Case 27: appendRecord is idempotent by (runId, seq) — a second append with
+    // a seq already present is a no-op (first write wins), like appendInbox.
+    it('case 27: appendRecord idempotent by (runId, seq)', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-record-27';
+      await store.create(runId, makeInitialRun(agent, agentName));
+
+      const first: RunRecordEntry = {
+        kind: 'node',
+        record: { seq: 0, nodePath: 'main', nodeType: 'scope', at: 1 },
+      };
+      await store.appendRecord(runId, first);
+
+      // Same seq, different payload => dropped (first write wins).
+      const dup: RunRecordEntry = {
+        kind: 'node',
+        record: { seq: 0, nodePath: 'other', nodeType: 'loop', at: 2 },
+      };
+      await store.appendRecord(runId, dup);
+
+      const retrieved = await store.get(runId);
+      const recording = retrieved!.recording ?? [];
+      expect(recording).toHaveLength(1);
+      expect(recording[0]).toEqual(first);
+    });
+
+    // Case 28: DURABILITY — the recording stream survives a store reopen.
+    // Skipped for in-memory stores with no reopen, like case 12.
+    it('case 28: recording survives reopen', async () => {
+      await openStore();
+      if (!reopen) {
+        return;
+      }
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-record-28';
+      await store.create(runId, makeInitialRun(agent, agentName));
+
+      const entries: RunRecordEntry[] = [
+        {
+          kind: 'node',
+          record: { seq: 0, nodePath: 'main', nodeType: 'scope', at: 1 },
+        },
+        {
+          kind: 'model',
+          record: {
+            seq: 1,
+            nodePath: 'main/assistant',
+            callIndex: 0,
+            provider: 'claude',
+            requestDigest: 'd',
+            request: { messages: ['hi'] },
+            response: { text: 'yo' },
+            at: 2,
+          },
+        },
+      ];
+      for (const entry of entries) {
+        await store.appendRecord(runId, entry);
+      }
+
+      const fresh = await reopen();
+      const reconstructed = await fresh.get(runId);
+      const recording = reconstructed!.recording ?? [];
+      expect(recording).toHaveLength(2);
+      expect(recording.map((e) => e.record.seq)).toEqual([0, 1]);
+      expect(recording[1]).toEqual(entries[1]);
+    });
+
+    // Case 29: delete cascades records — a recreated runId must not fold the old
+    // incarnation's record rows into the new run.
+    it('case 29: delete cascades records', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-record-29';
+      await store.create(runId, makeInitialRun(agent, agentName));
+      await store.appendRecord(runId, {
+        kind: 'node',
+        record: { seq: 0, nodePath: 'main', nodeType: 'scope', at: 1 },
+      });
+
+      await store.delete(runId);
+      expect(await store.has(runId)).toBe(false);
+
+      await store.create(runId, makeInitialRun(agent, agentName));
+      const reconstructed = await store.get(runId);
+      expect(reconstructed!.recording ?? []).toHaveLength(0);
+    });
+
+    // Case 30: recordLevel is fixed at create time and round-trips on the run,
+    // including across a reopen when the backend is durable.
+    it('case 30: recordLevel round-trips on the run', async () => {
+      await openStore();
+      const agentName = Object.keys(agents)[0];
+      const agent = agents[agentName];
+      const runId = 'run-record-30';
+      const recordLevel: RecordLevel = 'full';
+      await store.create(
+        runId,
+        makeInitialRun(agent, agentName, { recordLevel }),
+      );
+
+      const retrieved = await store.get(runId);
+      expect(retrieved!.recordLevel).toBe('full');
+
+      if (reopen) {
+        const fresh = await reopen();
+        const reconstructed = await fresh.get(runId);
+        expect(reconstructed!.recordLevel).toBe('full');
+      }
     });
   });
 }

--- a/packages/store-libsql/src/index.ts
+++ b/packages/store-libsql/src/index.ts
@@ -9,6 +9,8 @@ import {
   type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
+  type RecordLevel,
+  type RunRecordEntry,
   type RunStoreLease,
   type RunStoreLeaseState,
   type SessionCheckpointDelta,
@@ -287,8 +289,9 @@ export class LibsqlRunStore implements DurableRunStore {
         graph_suspended_at,
         services_json,
         initial_session_json,
-        graph_manifest_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        graph_manifest_json,
+        record_level
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         runId,
         run.agentName,
@@ -298,6 +301,7 @@ export class LibsqlRunStore implements DurableRunStore {
         jsonOrNull(run.services),
         JSON.stringify(run.initial.toJSON()),
         jsonOrNull(run.graphManifest),
+        run.recordLevel ?? null,
       ],
     });
   }
@@ -491,6 +495,21 @@ export class LibsqlRunStore implements DurableRunStore {
     });
   }
 
+  async appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    // INSERT OR IGNORE for (run_id, seq) idempotency — first write wins, so a
+    // re-append of a seq already present is silently dropped.
+    await this.client.execute({
+      sql: `INSERT OR IGNORE INTO records (run_id, seq, kind, entry_json)
+            VALUES (?, ?, ?, ?)`,
+      args: [runId, entry.record.seq, entry.kind, JSON.stringify(entry)],
+    });
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     // Deleting the parent runs row is sufficient: the schema declares
@@ -527,7 +546,8 @@ export class LibsqlRunStore implements DurableRunStore {
         graph_suspended_at TEXT,
         services_json TEXT,
         initial_session_json TEXT NOT NULL,
-        graph_manifest_json TEXT
+        graph_manifest_json TEXT,
+        record_level TEXT
       );
 
       CREATE TABLE IF NOT EXISTS session_deltas (
@@ -590,6 +610,15 @@ export class LibsqlRunStore implements DurableRunStore {
         FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
       );
 
+      CREATE TABLE IF NOT EXISTS records (
+        run_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        PRIMARY KEY (run_id, seq),
+        FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+      );
+
       CREATE TABLE IF NOT EXISTS lease (
         id INTEGER PRIMARY KEY CHECK (id = 1),
         holder TEXT NOT NULL,
@@ -610,7 +639,8 @@ export class LibsqlRunStore implements DurableRunStore {
     // 1. Load the run row.
     const runRes = await this.client.execute({
       sql: `SELECT run_id, agent_name, status, graph_cursor, graph_suspended_at,
-                   services_json, initial_session_json, graph_manifest_json
+                   services_json, initial_session_json, graph_manifest_json,
+                   record_level
             FROM runs WHERE run_id = ?`,
       args: [runId],
     });
@@ -627,6 +657,7 @@ export class LibsqlRunStore implements DurableRunStore {
       services_json: r[5] as string | null,
       initial_session_json: r[6] as string,
       graph_manifest_json: r[7] as string | null,
+      record_level: r[8] as RecordLevel | null,
     };
 
     // 2. Gather session deltas ordered by seq.
@@ -719,7 +750,17 @@ export class LibsqlRunStore implements DurableRunStore {
       return timer;
     });
 
-    // 8. Delegate assembly to the shared reconstruction helper.
+    // 8. Gather the recording stream ordered by seq.
+    const recordRes = await this.client.execute({
+      sql: `SELECT entry_json
+            FROM records WHERE run_id = ? ORDER BY seq ASC`,
+      args: [runId],
+    });
+    const records: RunRecordEntry[] = recordRes.rows.map(
+      (rrow) => parseJsonRequired(rrow[0] as string) as RunRecordEntry,
+    );
+
+    // 9. Delegate assembly to the shared reconstruction helper.
     return reconstructStoredRun(
       {
         agentName: row.agent_name,
@@ -735,6 +776,8 @@ export class LibsqlRunStore implements DurableRunStore {
         outbox,
         providerSessions,
         timers,
+        records,
+        recordLevel: row.record_level ?? undefined,
       },
       this.agents,
     );

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -9,6 +9,8 @@ import {
   type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
+  type RecordLevel,
+  type RunRecordEntry,
   type RunStoreLease,
   type RunStoreLeaseState,
   type SessionCheckpointDelta,
@@ -345,8 +347,9 @@ export class PostgresRunStore implements DurableRunStore {
           graph_suspended_at,
           services_json,
           initial_session_json,
-          graph_manifest_json
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          graph_manifest_json,
+          record_level
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
         [
           runId,
           run.agentName,
@@ -356,6 +359,7 @@ export class PostgresRunStore implements DurableRunStore {
           jsonOrNull(run.services),
           JSON.stringify(run.initial.toJSON()),
           jsonOrNull(run.graphManifest),
+          run.recordLevel ?? null,
         ],
       );
     } finally {
@@ -596,6 +600,27 @@ export class PostgresRunStore implements DurableRunStore {
     }
   }
 
+  async appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const client = await this.pool.connect();
+    try {
+      // INSERT ... ON CONFLICT DO NOTHING for (run_id, seq) idempotency —
+      // first write wins, so a re-append of a seq already present is a no-op.
+      await client.query(
+        `INSERT INTO records (run_id, seq, kind, entry_json)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (run_id, seq) DO NOTHING`,
+        [runId, entry.record.seq, entry.kind, JSON.stringify(entry)],
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     // Delete the run AND all of its child rows in a single transaction.
@@ -619,6 +644,7 @@ export class PostgresRunStore implements DurableRunStore {
         runId,
       ]);
       await client.query('DELETE FROM timers WHERE run_id = $1', [runId]);
+      await client.query('DELETE FROM records WHERE run_id = $1', [runId]);
       await client.query('DELETE FROM runs WHERE run_id = $1', [runId]);
       await client.query('COMMIT');
     } catch (error) {
@@ -662,7 +688,8 @@ export class PostgresRunStore implements DurableRunStore {
           graph_suspended_at TEXT,
           services_json TEXT,
           initial_session_json TEXT NOT NULL,
-          graph_manifest_json TEXT
+          graph_manifest_json TEXT,
+          record_level TEXT
         )`,
         session_deltas: `CREATE TABLE session_deltas (
           run_id TEXT NOT NULL,
@@ -712,6 +739,13 @@ export class PostgresRunStore implements DurableRunStore {
           fired_at BIGINT,
           PRIMARY KEY (run_id, id)
         )`,
+        records: `CREATE TABLE records (
+          run_id TEXT NOT NULL,
+          seq BIGINT NOT NULL,
+          kind TEXT NOT NULL,
+          entry_json TEXT NOT NULL,
+          PRIMARY KEY (run_id, seq)
+        )`,
         lease: `CREATE TABLE lease (
           id INTEGER PRIMARY KEY,
           holder TEXT NOT NULL,
@@ -746,7 +780,8 @@ export class PostgresRunStore implements DurableRunStore {
     // 1. Load the run row
     const runRes = await client.query(
       `SELECT run_id, agent_name, status, graph_cursor, graph_suspended_at,
-              services_json, initial_session_json, graph_manifest_json
+              services_json, initial_session_json, graph_manifest_json,
+              record_level
        FROM runs WHERE run_id = $1`,
       [runId],
     );
@@ -762,6 +797,7 @@ export class PostgresRunStore implements DurableRunStore {
       services_json: string | null;
       initial_session_json: string;
       graph_manifest_json: string | null;
+      record_level: RecordLevel | null;
     };
 
     // 2. Gather session deltas in seq order (parsed + normalized).
@@ -888,7 +924,16 @@ export class PostgresRunStore implements DurableRunStore {
       return timer;
     });
 
-    // 8. Delegate assembly to the shared reconstruction helper.
+    // 8. Gather the recording stream ordered by seq.
+    const recordRes = await client.query(
+      `SELECT entry_json FROM records WHERE run_id = $1 ORDER BY seq ASC`,
+      [runId],
+    );
+    const records: RunRecordEntry[] = (
+      recordRes.rows as { entry_json: string }[]
+    ).map((rrow) => parseJsonRequired(rrow.entry_json) as RunRecordEntry);
+
+    // 9. Delegate assembly to the shared reconstruction helper.
     return reconstructStoredRun(
       {
         agentName: row.agent_name,
@@ -904,6 +949,8 @@ export class PostgresRunStore implements DurableRunStore {
         outbox,
         providerSessions,
         timers,
+        records,
+        recordLevel: row.record_level ?? undefined,
       },
       this.agents,
     );

--- a/packages/store-redis/src/index.ts
+++ b/packages/store-redis/src/index.ts
@@ -8,6 +8,8 @@ import type {
   Inbound,
   OnceScope,
   ProviderSessionBinding,
+  RecordLevel,
+  RunRecordEntry,
   RunStoreLease,
   RunStoreLeaseState,
   SessionCheckpointDelta,
@@ -53,6 +55,10 @@ interface RunDocument {
   providerSessions: Record<string, ProviderSessionBinding>;
   /** Durable timers, upserted by id. Optional so old docs stay readable. */
   timers?: DurableTimer[];
+  /** Seq-ordered recording stream, appended by seq. Optional for old docs. */
+  recording?: RunRecordEntry[];
+  /** Recording verbosity for this run. Optional so old docs stay readable. */
+  recordLevel?: RecordLevel;
 }
 
 interface SerializedDelta {
@@ -364,6 +370,8 @@ export class RedisRunStore implements DurableRunStore {
       outbox: [],
       providerSessions: {},
       timers: [],
+      recording: [],
+      recordLevel: run.recordLevel,
     };
     await this.saveDoc(runId, doc);
     await this.client.sadd(this.indexKey(), runId);
@@ -525,6 +533,26 @@ export class RedisRunStore implements DurableRunStore {
     await this.saveDoc(runId, doc);
   }
 
+  async appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    await this.assertFence(fence);
+    const doc = await this.loadDoc(runId);
+    if (!doc) {
+      return;
+    }
+    const recording = (doc.recording ??= []);
+    // Idempotent by (runId, seq): first write wins, mirroring the inbox offset
+    // dedup — a re-append of a seq already present is dropped.
+    const seq = entry.record.seq;
+    if (!recording.some((existing) => existing.record.seq === seq)) {
+      recording.push(entry);
+      await this.saveDoc(runId, doc);
+    }
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     await this.assertFence(fence);
     await this.client.del(this.runKey(runId));
@@ -580,6 +608,8 @@ export class RedisRunStore implements DurableRunStore {
         outbox: doc.outbox,
         providerSessions: doc.providerSessions,
         timers: doc.timers ?? [],
+        records: doc.recording ?? [],
+        recordLevel: doc.recordLevel,
       },
       this.agents,
     );

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -12,6 +12,8 @@ import {
   type InboundKind,
   type OnceScope,
   type ProviderSessionBinding,
+  type RecordLevel,
+  type RunRecordEntry,
   type RunStoreLease,
   type RunStoreLeaseState,
   type SessionCheckpointDelta,
@@ -188,6 +190,7 @@ export interface SqliteWriteJournalEntry {
     | 'upsertOutbox'
     | 'recordProviderSession'
     | 'upsertTimer'
+    | 'appendRecord'
     | 'patch'
     | 'delete';
   summary: string;
@@ -210,6 +213,7 @@ interface RunRow {
   services_json: string | null;
   initial_session_json: string;
   graph_manifest_json: string | null;
+  record_level: RecordLevel | null;
 }
 
 interface SessionDeltaRow {
@@ -260,6 +264,13 @@ interface TimerRow {
   fired_at: number | null;
 }
 
+interface RecordRow {
+  run_id: string;
+  seq: number;
+  kind: RunRecordEntry['kind'];
+  entry_json: string;
+}
+
 /**
  * SQLite restart substrate for PromptTrail durable runs.
  *
@@ -288,6 +299,7 @@ export class SqliteRunStore implements DurableRunStore {
   private readonly upsertOutboxStmt: Database.Statement;
   private readonly upsertProviderSessionStmt: Database.Statement;
   private readonly upsertTimerStmt: Database.Statement;
+  private readonly appendRecordStmt: Database.Statement;
 
   constructor(options: SqliteRunStoreOptions) {
     const dbPath = options.path ?? join(cwd(), '.data', 'prompttrail.db');
@@ -306,9 +318,10 @@ export class SqliteRunStore implements DurableRunStore {
         graph_suspended_at,
         services_json,
         initial_session_json,
-        graph_manifest_json
+        graph_manifest_json,
+        record_level
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     this.updateRunStmt = this.db.prepare(`
       UPDATE runs
@@ -375,6 +388,13 @@ export class SqliteRunStore implements DurableRunStore {
         fired_at = excluded.fired_at
     `);
 
+    // Idempotent by (run_id, seq): first write wins, so a re-append of a seq
+    // already present is silently ignored (like the inbox offset discipline).
+    this.appendRecordStmt = this.db.prepare(`
+      INSERT OR IGNORE INTO records (run_id, seq, kind, entry_json)
+      VALUES (?, ?, ?, ?)
+    `);
+
     this.sqliteLease = new SqliteLease(this.db, options.now ?? Date.now);
     this.lease = this.sqliteLease;
 
@@ -412,6 +432,7 @@ export class SqliteRunStore implements DurableRunStore {
       jsonOrNull(run.services),
       JSON.stringify(run.initial.toJSON()),
       jsonOrNull(run.graphManifest),
+      run.recordLevel ?? null,
     );
     this.runs.set(runId, run);
     this.recordJournal(
@@ -615,6 +636,31 @@ export class SqliteRunStore implements DurableRunStore {
     );
   }
 
+  async appendRecord(
+    runId: string,
+    entry: RunRecordEntry,
+    fence?: number,
+  ): Promise<void> {
+    this.assertFence(fence);
+    const run = this.runs.get(runId);
+    if (!run) {
+      return;
+    }
+    const seq = entry.record.seq;
+    this.appendRecordStmt.run(runId, seq, entry.kind, JSON.stringify(entry));
+    const recording = (run.recording ??= []);
+    // First write wins on (run_id, seq): keep the in-memory stream in sync with
+    // the INSERT OR IGNORE semantics above.
+    if (!recording.some((existing) => existing.record.seq === seq)) {
+      recording.push(entry);
+    }
+    this.recordJournal(
+      runId,
+      'appendRecord',
+      `INSERT records (seq ${seq}, ${entry.kind})`,
+    );
+  }
+
   async delete(runId: string, fence?: number): Promise<void> {
     this.assertFence(fence);
     this.deleteRunStmt.run(runId);
@@ -650,7 +696,8 @@ export class SqliteRunStore implements DurableRunStore {
         graph_suspended_at TEXT,
         services_json TEXT,
         initial_session_json TEXT NOT NULL,
-        graph_manifest_json TEXT
+        graph_manifest_json TEXT,
+        record_level TEXT
       );
 
       CREATE TABLE IF NOT EXISTS session_deltas (
@@ -713,6 +760,15 @@ export class SqliteRunStore implements DurableRunStore {
         FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
       );
 
+      CREATE TABLE IF NOT EXISTS records (
+        run_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        PRIMARY KEY (run_id, seq),
+        FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+      );
+
       CREATE TABLE IF NOT EXISTS lease (
         id INTEGER PRIMARY KEY CHECK (id = 1),
         holder TEXT NOT NULL,
@@ -745,6 +801,9 @@ export class SqliteRunStore implements DurableRunStore {
     const timerRows = this.db
       .prepare('SELECT * FROM timers ORDER BY run_id, id')
       .all() as TimerRow[];
+    const recordRows = this.db
+      .prepare('SELECT * FROM records ORDER BY run_id, seq')
+      .all() as RecordRow[];
 
     // Group child rows per run_id, preserving the SELECT ordering so each
     // run's components (deltas in seq order, inbox in offset order, etc.) are
@@ -755,6 +814,7 @@ export class SqliteRunStore implements DurableRunStore {
     const outboxByRun = groupBy(outboxRows, (row) => row.run_id);
     const providerByRun = groupBy(providerRows, (row) => row.run_id);
     const timersByRun = groupBy(timerRows, (row) => row.run_id);
+    const recordsByRun = groupBy(recordRows, (row) => row.run_id);
 
     for (const row of runRows) {
       const deltas: SessionCheckpointDelta<any>[] = (
@@ -804,6 +864,10 @@ export class SqliteRunStore implements DurableRunStore {
         (trow) => timerFromRow(trow),
       );
 
+      const records: RunRecordEntry[] = (
+        recordsByRun.get(row.run_id) ?? []
+      ).map((rrow) => parseJsonRequired(rrow.entry_json) as RunRecordEntry);
+
       const run = reconstructStoredRun(
         {
           agentName: row.agent_name,
@@ -819,6 +883,8 @@ export class SqliteRunStore implements DurableRunStore {
           outbox,
           providerSessions,
           timers,
+          records,
+          recordLevel: row.record_level ?? undefined,
         },
         agents,
       );


### PR DESCRIPTION
First implementation slice of design-docs/replay-and-self-deploy.md Appendix B0 (the substrate for B1 deterministic replay and the eventual replay-diff gated self-deploy):

- RunRecordEntry stream: NodeBreadcrumb / ModelCallRecord / ToolCallRecord in ONE seq-ordered append-only sequence per run — the round-3-corrected schema (no (nodePath,callIndex) keying; loops share paths)
- StoredRun.recording + recordLevel (off/decisions/full; per-run, stamped at create from the app option — claw's sampled-fraction recording rides this later)
- appendRecord(runId, entry, fence?) idempotent by (runId, seq), fenced under the lease, across all five backends (sqlite/libsql FK-cascade records table, postgres explicit txn delete, redis in-doc array); store-common reconstruction
- Conformance cases 26–30 (ordered round-trip, seq idempotency, reopen survival, delete cascade, recordLevel round-trip)

No capture logic yet — B0b wires executeGraphNode breadcrumbs, the executePromptTrailTool funnel, and the wrapModelCall middleware with per-provider request normalization.

core 757 / stores 60+30×3 / claw 36 / discord 16 / cron 10, typecheck/build/prettier green.