### PR TITLE
feat: B0 recording layer — capture half

### DIFF
--- a/claw/src/skills/supervisor.test.ts
+++ b/claw/src/skills/supervisor.test.ts
@@ -22,7 +22,6 @@ import {
   runSupervisorCommand,
   SkillRegistry,
   supervisorAuthorized,
-  templateSynthesizer,
   type Skill,
   type SkillLoaderContext,
   type SkillProvenance,

--- a/packages/core/src/__tests__/unit/public_api.test.ts
+++ b/packages/core/src/__tests__/unit/public_api.test.ts
@@ -71,12 +71,17 @@ describe('public API surface', () => {
       'createAgentGraph',
       'createAgentGraphManifest',
       'createProviderFileContentPart',
+      'createRunRecorder',
       'createSession',
+      'digest',
       'isProviderFileReferenceExpired',
       'manifestConfigDigest',
+      'maxRecordSeq',
       'memoryStore',
+      'normalizeMessagesForDigest',
       'on',
       'parseDuration',
+      'stableStringify',
       'validateAgentGraph',
     ]);
   });

--- a/packages/core/src/__tests__/unit/recording.test.ts
+++ b/packages/core/src/__tests__/unit/recording.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type {
+  CodexAppServerClient,
+  CodexSkillListResult,
+  CodexThreadStartParams,
+  CodexThreadStartResult,
+  CodexTurnResult,
+  CodexTurnStartParams,
+} from '../../codex_app_server';
+import { MemoryRunStore, PromptTrail } from '../../durable';
+import type { RunRecordEntry, StoredRun } from '../../durable';
+import {
+  createRunRecorder,
+  digest,
+  maxRecordSeq,
+  stableStringify,
+} from '../../recording';
+import { Session } from '../../session';
+import { Source } from '../../source';
+import { Agent } from '../../templates';
+import { Tool } from '../../tool';
+
+// Minimal fake Codex App Server client, mirroring codex_turn.test.ts.
+class FakeCodexClient implements CodexAppServerClient {
+  async listSkills(): Promise<CodexSkillListResult | unknown[]> {
+    return { skills: [] };
+  }
+  async startThread(
+    _params: CodexThreadStartParams,
+  ): Promise<CodexThreadStartResult> {
+    return { threadId: 'thread-1' };
+  }
+  async startTurn(params: CodexTurnStartParams): Promise<CodexTurnResult> {
+    return {
+      threadId: params.threadId,
+      turnId: 'turn-1',
+      status: 'completed',
+      finalAnswer: 'Codex result',
+    };
+  }
+}
+
+// A mocked LlmSource that emits a tool call, so the assistant node produces a
+// ModelCallRecord and the following tools node produces a ToolCallRecord.
+function toolCallingSource() {
+  return Source.llm({ temperature: 0 })
+    .mock()
+    .mockResponse({
+      content: 'calling echo',
+      toolCalls: [{ id: 'call-1', name: 'echo', arguments: { x: 1 } }],
+    });
+}
+
+const echoTool = Tool.create({
+  name: 'echo',
+  description: 'Echoes its input.',
+  inputSchema: z.object({ x: z.number() }),
+  effect: { idempotencyKey: 'echo:1' },
+  execute: (input: { x: number }) => `echo:${input.x}`,
+});
+
+// system + receive + assistant(tool call) + tools + conditional(then branch).
+function recordingAgent() {
+  return Agent.create('rec')
+    .system('sys', 'be helpful')
+    .inbox('inbound')
+    .tool('echo', echoTool)
+    .assistant('ask', toolCallingSource())
+    .tools('run')
+    .conditional(
+      'branch',
+      () => true,
+      (a) => a.system('note', 'branch taken'),
+    );
+}
+
+function sortedRecording(run: StoredRun<any> | undefined): RunRecordEntry[] {
+  return [...(run?.recording ?? [])].sort(
+    (a, b) => a.record.seq - b.record.seq,
+  );
+}
+
+describe('B0 recording — pure helpers', () => {
+  it('stableStringify sorts object keys deterministically', () => {
+    expect(stableStringify({ b: 1, a: 2 })).toBe(
+      stableStringify({ a: 2, b: 1 }),
+    );
+    expect(stableStringify({ a: 2, b: 1 })).toBe('{"a":2,"b":1}');
+    // Nested + arrays keep array order but sort keys recursively.
+    expect(stableStringify({ z: [{ q: 1, p: 2 }] })).toBe(
+      '{"z":[{"p":2,"q":1}]}',
+    );
+    expect(stableStringify(undefined)).toBe('null');
+  });
+
+  it('digest is stable and order-independent', () => {
+    expect(digest({ a: 1, b: 2 })).toBe(digest({ b: 2, a: 1 }));
+    expect(digest({ a: 1 })).not.toBe(digest({ a: 2 }));
+  });
+
+  it('maxRecordSeq returns -1 for an empty stream', () => {
+    expect(maxRecordSeq(undefined)).toBe(-1);
+    expect(maxRecordSeq([])).toBe(-1);
+  });
+});
+
+describe('B0 recording — capture', () => {
+  it("'decisions' produces the expected ordered stream", async () => {
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({
+      agents: { rec: recordingAgent() },
+      store,
+      recording: 'decisions',
+    });
+
+    const result = await app.run({
+      agent: 'rec',
+      runId: 'rec-1',
+      input: 'hello',
+      checkpoint: true,
+    });
+    expect(result.status).toBe('done');
+
+    const entries = sortedRecording(await store.get('rec-1'));
+    const shape = entries.map((entry) => {
+      if (entry.kind === 'node') {
+        return {
+          kind: 'node',
+          nodeType: entry.record.nodeType,
+          branch: entry.record.branch,
+        };
+      }
+      if (entry.kind === 'model') {
+        return { kind: 'model', provider: entry.record.provider };
+      }
+      return { kind: 'tool', toolName: entry.record.toolName };
+    });
+
+    expect(shape).toEqual([
+      { kind: 'node', nodeType: 'system', branch: undefined },
+      { kind: 'node', nodeType: 'inbox', branch: undefined },
+      { kind: 'node', nodeType: 'assistant', branch: undefined },
+      { kind: 'model', provider: 'assistant' },
+      { kind: 'node', nodeType: 'tools', branch: undefined },
+      { kind: 'tool', toolName: 'echo' },
+      { kind: 'node', nodeType: 'conditional', branch: undefined },
+      { kind: 'node', nodeType: 'conditional', branch: 'then' },
+      { kind: 'node', nodeType: 'system', branch: undefined },
+    ]);
+
+    // seq is a dense monotonic 0..N stream.
+    expect(entries.map((entry) => entry.record.seq)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8,
+    ]);
+
+    const model = entries.find((entry) => entry.kind === 'model');
+    expect(model?.kind).toBe('model');
+    if (model?.kind === 'model') {
+      expect(model.record.requestDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(model.record.response).toBeDefined();
+      // 'decisions' drops the normalized request.
+      expect(model.record.request).toBeUndefined();
+      expect(model.record.nodePath).toBe('rec/ask');
+      expect(model.record.callIndex).toBe(0);
+    }
+
+    const tool = entries.find((entry) => entry.kind === 'tool');
+    expect(tool?.kind).toBe('tool');
+    if (tool?.kind === 'tool') {
+      expect(tool.record.argsDigest).toBe(digest({ x: 1 }));
+      expect(tool.record.input).toBeUndefined(); // dropped at 'decisions'
+      expect(tool.record.result).toBeDefined();
+      expect(tool.record.effect).toEqual({ idempotencyKey: 'echo:1' });
+      expect(tool.record.nodePath).toBe('rec/run');
+    }
+  });
+
+  it("'full' stores the normalized request and parsed tool input", async () => {
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({
+      agents: { rec: recordingAgent() },
+      store,
+      recording: 'full',
+    });
+
+    await app.run({
+      agent: 'rec',
+      runId: 'rec-full',
+      input: 'hello',
+      checkpoint: true,
+    });
+
+    const entries = sortedRecording(await store.get('rec-full'));
+    const model = entries.find((entry) => entry.kind === 'model');
+    if (model?.kind === 'model') {
+      expect(model.record.request).toBeDefined();
+      expect(
+        (model.record.request as { messages: unknown }).messages,
+      ).toBeDefined();
+      // requestMeta = the source manifest descriptor (resolved LLMOptions).
+      expect((model.record.request as { meta: unknown }).meta).toBeTruthy();
+    }
+    const tool = entries.find((entry) => entry.kind === 'tool');
+    if (tool?.kind === 'tool') {
+      expect(tool.record.input).toEqual({ x: 1 });
+    }
+  });
+
+  it("'off' records nothing", async () => {
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({
+      agents: { rec: recordingAgent() },
+      store,
+      // recording defaults to 'off'
+    });
+
+    await app.run({
+      agent: 'rec',
+      runId: 'rec-off',
+      input: 'hello',
+      checkpoint: true,
+    });
+
+    const run = await store.get('rec-off');
+    expect(run?.recording ?? []).toEqual([]);
+  });
+
+  it('seq continues monotonically across suspend/resume', async () => {
+    const store = new MemoryRunStore();
+    const suspendable = Agent.create('susp')
+      .assistant(
+        'a1',
+        Source.llm({ temperature: 0 })
+          .mock()
+          .mockResponse({ content: 'first' }),
+      )
+      .awaitInput('gate')
+      .assistant(
+        'a2',
+        Source.llm({ temperature: 0 })
+          .mock()
+          .mockResponse({ content: 'second' }),
+      );
+    const app = PromptTrail.app({
+      agents: { susp: suspendable },
+      store,
+      recording: 'decisions',
+    });
+
+    const first = await app.run({
+      agent: 'susp',
+      runId: 'susp-1',
+      checkpoint: true,
+    });
+    expect(first.status).toBe('suspended');
+    const afterSuspend = sortedRecording(await store.get('susp-1'));
+    const suspendMaxSeq = maxRecordSeq(afterSuspend);
+    expect(suspendMaxSeq).toBeGreaterThanOrEqual(1);
+
+    const resumed = await app.send({ runId: 'susp-1', input: 'go' });
+    expect(resumed.status).toBe('done');
+
+    const all = sortedRecording(await store.get('susp-1'));
+    const seqs = all.map((entry) => entry.record.seq);
+    // Strictly increasing, no collisions across the resume boundary.
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length);
+    expect(Math.max(...seqs)).toBeGreaterThan(suspendMaxSeq);
+    // Two assistant model calls total, across the two resumes.
+    expect(all.filter((entry) => entry.kind === 'model')).toHaveLength(2);
+  });
+
+  it('produces identical requestDigests for two identical runs', async () => {
+    const runOnce = async (runId: string) => {
+      const store = new MemoryRunStore();
+      const app = PromptTrail.app({
+        agents: { rec: recordingAgent() },
+        store,
+        recording: 'decisions',
+      });
+      await app.run({ agent: 'rec', runId, input: 'hello', checkpoint: true });
+      const entries = sortedRecording(await store.get(runId));
+      const model = entries.find((entry) => entry.kind === 'model');
+      return model?.kind === 'model' ? model.record.requestDigest : undefined;
+    };
+
+    const a = await runOnce('rec-a');
+    const b = await runOnce('rec-b');
+    expect(a).toBeDefined();
+    expect(a).toBe(b);
+  });
+
+  it('records under lease mode via the fenced store', async () => {
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({
+      agents: { rec: recordingAgent() },
+      store,
+      recording: 'decisions',
+      lease: { holder: 'solo', ttlMs: 10_000 },
+    });
+    await app.start();
+    try {
+      await app.run({
+        agent: 'rec',
+        runId: 'rec-lease',
+        input: 'hello',
+        checkpoint: true,
+      });
+    } finally {
+      await app.stop();
+    }
+
+    const entries = sortedRecording(await store.get('rec-lease'));
+    expect(entries.some((entry) => entry.kind === 'model')).toBe(true);
+    expect(entries.some((entry) => entry.kind === 'tool')).toBe(true);
+  });
+
+  it('captures a codex turn model record with provider "codex"', async () => {
+    const store = new MemoryRunStore();
+    const client = new FakeCodexClient();
+    const agent = Agent.create('codexAgent')
+      .user('do it')
+      .codex({ client, model: 'gpt-5.4-nano' });
+    const app = PromptTrail.app({
+      agents: { codexAgent: agent },
+      store,
+      recording: 'decisions',
+    });
+
+    await app.run({
+      agent: 'codexAgent',
+      runId: 'codex-1',
+      checkpoint: true,
+    });
+
+    const entries = sortedRecording(await store.get('codex-1'));
+    const model = entries.find((entry) => entry.kind === 'model');
+    expect(model?.kind).toBe('model');
+    if (model?.kind === 'model') {
+      expect(model.record.provider).toBe('codex');
+      expect(model.record.requestDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(model.record.response).toBeDefined();
+    }
+  });
+});
+
+describe('B0 recording — recorder unit', () => {
+  it('assigns per-nodePath callIndex and fire-ordered seq', async () => {
+    const appended: RunRecordEntry[] = [];
+    const recorder = createRunRecorder({
+      level: 'full',
+      initialSeq: -1,
+      append: async (entry) => {
+        appended.push(entry);
+      },
+      now: () => 123,
+    });
+
+    const session = Session.create().addMessage({
+      type: 'user',
+      content: 'hi',
+    });
+    recorder.node({ nodePath: 'g/a', nodeType: 'assistant' });
+    recorder.model({
+      nodePath: 'g/a',
+      provider: 'assistant',
+      requestSession: session,
+      response: { content: 'x' },
+    });
+    recorder.model({
+      nodePath: 'g/a',
+      provider: 'assistant',
+      requestSession: session,
+      response: { content: 'y' },
+    });
+    await recorder.drain();
+
+    expect(appended.map((entry) => entry.record.seq)).toEqual([0, 1, 2]);
+    const models = appended.filter((entry) => entry.kind === 'model');
+    expect(
+      models.map(
+        (entry) =>
+          (entry as { record: { callIndex: number } }).record.callIndex,
+      ),
+    ).toEqual([0, 1]);
+    expect(appended[0].record.at).toBe(123);
+  });
+});

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionDurableBoundary,
   ExecutionEffectDeclaration,
 } from './interceptors';
+import type { Recorder } from './recording';
 import type { Session } from './session';
 
 export type ExecutionMode = 'prompttrail' | 'provider' | 'runtime';
@@ -39,6 +40,15 @@ export interface ToolExecutionContext {
   effect?: ExecutionEffectDeclaration;
   idempotencyKey?: string;
   durable?: ExecutionDurableBoundary;
+  /**
+   * B0 recording handle (Appendix B0 work item 1). Threaded in by the graph
+   * tools node — the funnel where a `nodePath` is in scope. Provider vendor-loop
+   * tool callbacks (builtin/MCP) run without a nodePath and leave this unset;
+   * those calls ride the model/provider response instead (round-3).
+   */
+  recorder?: Recorder;
+  /** Graph path of the tools node issuing the call; scopes `callIndex`. */
+  recordNodePath?: string;
 }
 
 export type CallToolContent =

--- a/packages/core/src/durable.ts
+++ b/packages/core/src/durable.ts
@@ -36,6 +36,7 @@ import {
   GraphExecutionSuspended,
   type GraphInboundInput,
 } from './graph_executor';
+import { createRunRecorder, maxRecordSeq, type Recorder } from './recording';
 import {
   AgentGraphVersionError,
   createAgentGraphManifest,
@@ -2361,6 +2362,20 @@ export class PromptTrailApp {
       this.recordOnce(runId, entry),
     );
 
+    // B0 recorder (Appendix B0). Created per run when recording is enabled; seq
+    // is seeded from the max seq already in run.recording so it stays monotonic
+    // across suspend/resume. Appends go through the (fenced) store so recording
+    // works under lease mode. `this.now` is the shared injectable clock.
+    const recorder: Recorder | undefined =
+      run.recordLevel && run.recordLevel !== 'off'
+        ? createRunRecorder({
+            level: run.recordLevel,
+            initialSeq: maxRecordSeq(run.recording),
+            append: (entry) => this.store.appendRecord(runId, entry),
+            now: this.now,
+          })
+        : undefined;
+
     try {
       const session = await executeAgentGraph<TVars>(
         {
@@ -2397,6 +2412,7 @@ export class PromptTrailApp {
           firedTimers: firedTimerIds(run),
           armTimer: (timerId, durationMs) =>
             this.armTimer(runId, run, timerId, durationMs),
+          recorder,
           observers: [
             async (event) => {
               await this.emitObservers(run, event);
@@ -2443,6 +2459,10 @@ export class PromptTrailApp {
         throw new CheckpointRollbackError(error, rollbackError);
       }
       throw error;
+    } finally {
+      // Flush the fire-ordered append chain so all records are durably written
+      // before the run returns (completion, suspension, or error).
+      await recorder?.drain();
     }
   }
 

--- a/packages/core/src/graph_executor.ts
+++ b/packages/core/src/graph_executor.ts
@@ -25,6 +25,7 @@ import {
   type AssistantMessage,
   type Message as PromptTrailMessage,
 } from './message';
+import type { Recorder } from './recording';
 import { Session, type Vars } from './session';
 import { parseDuration } from './duration';
 import { type ModelOutput, Source } from './source';
@@ -95,6 +96,12 @@ export interface GraphExecutionOptions<TVars extends Vars = Vars> {
    */
   firedTimers?: ReadonlySet<string>;
   armTimer?: (timerId: string, durationMs: number) => Promise<void>;
+  /**
+   * B0 recording handle (Appendix B0). Supplied by the durable runtime when the
+   * run's `recordLevel !== 'off'`; installed on the runtime so the model/tool
+   * funnels and node breadcrumbs capture through it.
+   */
+  recorder?: Recorder;
 }
 
 export interface GraphToolDurableBoundaryContext<TVars extends Vars = Vars> {
@@ -215,8 +222,10 @@ export async function executeAgentGraph<TVars extends Vars = Vars>(
         durableBoundary: options.durableBoundary,
         providerSessions: options.providerSessions,
         recordProviderSession: options.recordProviderSession,
+        recorder: options.recorder,
       });
   if (options.runtime) {
+    runtime.recorder = options.recorder ?? options.runtime.recorder;
     runtime.services = services;
     runtime.signal = signal;
     runtime.emitEvent = emitEvent;
@@ -423,6 +432,21 @@ async function executeGraphNode<TVars extends Vars>(
   if (state.skipNode?.(node, nodePath, state.session)) {
     return;
   }
+  // B0 node-enter breadcrumb (Appendix B0 work item 3). One per node entry;
+  // loop/goalAttempts iterations re-run under the SAME nodePath, so they appear
+  // as repeated breadcrumbs disambiguated by seq (the stream is seq-ordered, not
+  // a nodePath→record map). `currentNodePath` is also the fallback path for
+  // model/tool calls that do not thread one explicitly (structured/parallel via
+  // executeSource). The conditional node emits a SECOND breadcrumb carrying the
+  // chosen `branch` after its decision (see executeConditionalNode). Parallel
+  // emits no per-branch breadcrumbs: executeParallelNode runs its branches
+  // sequentially via executeSource under one nodePath, so branch order is
+  // reconstructed from model/tool record order (round-3).
+  const recorder = state.runtime.recorder;
+  if (recorder) {
+    recorder.currentNodePath = nodePath;
+    recorder.node({ nodePath, nodeType: node.type });
+  }
   switch (node.type) {
     case 'system':
       await executeSystemNode(node, nodePath, state);
@@ -602,6 +626,14 @@ async function executeConditionalNode<TVars extends Vars>(
   const branchId = resolveGraphCondition(data.condition, nodePath, state)
     ? 'then'
     : 'else';
+  // Second breadcrumb AFTER the decision, carrying the chosen branch — this is
+  // what lets a replayer reconstruct which child the conditional entered
+  // (the entry breadcrumb from executeGraphNode has no branch yet).
+  state.runtime.recorder?.node({
+    nodePath,
+    nodeType: 'conditional',
+    branch: branchId,
+  });
   const branchNodeIds = getConditionalBranchNodeIds(data.branches, branchId);
   if (branchNodeIds.length === 0) {
     return;
@@ -870,6 +902,11 @@ async function executeAssistantNode<TVars extends Vars>(
         (modelSession) =>
           resolveGraphAssistantInput(input, nodePath, modelSession, state),
         `Graph node ${nodePath} model execution`,
+        {
+          nodePath,
+          provider: 'assistant',
+          requestMeta: sourceRequestMeta(input),
+        },
       );
       validSession = modelCall.session;
       const output = normalizeAssistantOutput(modelCall.result, nodePath);
@@ -1127,6 +1164,26 @@ async function executeTemplateNode<TVars extends Vars>(
   state.session = await template.execute(state.session, state.runtime);
 }
 
+/**
+ * Resolved-request metadata for the B0 model record (Appendix B0 work item 4):
+ * a ModelSource exposes a stable, serializable manifest descriptor (provider +
+ * generation params + a digest of tool defs, NOT the full defs) that is folded
+ * into the request digest. Non-source inputs (function handlers, literals) have
+ * no manifest — their digest is over the input messages alone.
+ */
+function sourceRequestMeta(input: unknown): unknown {
+  if (
+    input &&
+    typeof (input as { getManifestDescriptor?: unknown })
+      .getManifestDescriptor === 'function'
+  ) {
+    return (
+      input as { getManifestDescriptor: () => unknown }
+    ).getManifestDescriptor();
+  }
+  return undefined;
+}
+
 async function resolveGraphAssistantInput<TVars extends Vars>(
   input: unknown,
   nodePath: string,
@@ -1308,6 +1365,8 @@ async function executeToolsNode<TVars extends Vars>(
               ? toolEffect
               : undefined,
             durable: durable ?? state.durableToolBoundary?.(context),
+            recorder: state.runtime.recorder,
+            recordNodePath: nodePath,
           });
         const result = state.durableToolExecution
           ? await state.durableToolExecution(context, executeTool)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -212,6 +212,20 @@ export type {
   Strategy,
 } from './templates';
 export type { SchemaType } from './templates/primitives/structured';
+export {
+  createRunRecorder,
+  digest,
+  maxRecordSeq,
+  normalizeMessagesForDigest,
+  stableStringify,
+} from './recording';
+export type {
+  CreateRecorderOptions,
+  Recorder,
+  RecorderModelInput,
+  RecorderNodeInput,
+  RecorderToolInput,
+} from './recording';
 export { Tool } from './tool';
 export type {
   CallToolResult,

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedExecutionTransition,
 } from './execution';
 import type { ProviderSessionBinding } from './provider_session';
+import type { Recorder } from './recording';
 import type { Session, Vars } from './session';
 
 export type ExecutionLifecyclePhase =
@@ -294,6 +295,14 @@ export interface ExecutionRuntimeState<TVars extends Vars = Vars> {
     nodePath: string,
     binding: ProviderSessionBinding,
   ) => Promise<void>;
+  /**
+   * B0 recording handle (design-docs replay-and-self-deploy.md, Appendix B0).
+   * Present only when the run's `recordLevel !== 'off'`; the model funnel
+   * (`executeRuntimeModelCall`, Codex/Claude turns), the tool funnel
+   * (`executePromptTrailTool`), and the graph executor's node breadcrumbs all
+   * capture through it when set.
+   */
+  recorder?: Recorder;
 }
 
 export function createExecutionRuntimeState<
@@ -312,6 +321,7 @@ export function createExecutionRuntimeState<
     nodePath: string,
     binding: ProviderSessionBinding,
   ) => Promise<void>;
+  recorder?: Recorder;
 }): ExecutionRuntimeState<TVars> {
   return {
     middleware: options?.middleware ?? [],
@@ -326,6 +336,7 @@ export function createExecutionRuntimeState<
     eventScopeId: options?.eventScopeId,
     providerSessions: options?.providerSessions,
     recordProviderSession: options?.recordProviderSession,
+    recorder: options?.recorder,
   };
 }
 

--- a/packages/core/src/recording.ts
+++ b/packages/core/src/recording.ts
@@ -1,0 +1,301 @@
+import { createHash } from 'node:crypto';
+import type {
+  ModelCallRecord,
+  NodeBreadcrumb,
+  RecordLevel,
+  RunRecordEntry,
+  ToolCallRecord,
+} from './durable';
+import type { Message } from './message';
+import type { Session } from './session';
+
+/**
+ * B0 recording — capture half of the replay layer (design-docs
+ * replay-and-self-deploy.md, Appendix B0). A per-run {@link Recorder} is created
+ * when `recordLevel !== 'off'`; it assigns a monotonic per-run `seq`, digests
+ * requests/args deterministically, and appends entries to the store's
+ * seq-ordered recording stream via a fire-ordered async sink.
+ *
+ * The three funnels feed this handle:
+ * - node-enter breadcrumbs (graph_executor `executeGraphNode`),
+ * - model calls at the `wrapModelCall` boundary (assistant via
+ *   `executeRuntimeModelCall`, plus Codex/Claude turns — three per-provider
+ *   normalizers, NOT one unified hash, per round-3),
+ * - tool calls at the `executePromptTrailTool` funnel (PromptTrail + graph
+ *   ai-sdk-wrapped tools; builtin/MCP/vendor-loop tools ride the model response).
+ */
+
+/**
+ * Deterministic stable JSON stringify with recursively sorted object keys, so a
+ * digest is stable across processes and independent of key insertion order.
+ * `undefined` and functions are dropped (objects) or nulled (array holes),
+ * matching JSON semantics for a content hash.
+ */
+export function stableStringify(value: unknown): string {
+  return stringify(value);
+}
+
+function stringify(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  const type = typeof value;
+  if (type === 'number') {
+    return Number.isFinite(value as number) ? String(value) : 'null';
+  }
+  if (type === 'boolean') {
+    return String(value);
+  }
+  if (type === 'string') {
+    return JSON.stringify(value);
+  }
+  if (type === 'bigint') {
+    return JSON.stringify(`${(value as bigint).toString()}n`);
+  }
+  if (type === 'undefined' || type === 'function' || type === 'symbol') {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stringify(item)).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((key) => {
+      const v = record[key];
+      return (
+        v !== undefined && typeof v !== 'function' && typeof v !== 'symbol'
+      );
+    })
+    .sort();
+  const parts = keys.map(
+    (key) => `${JSON.stringify(key)}:${stringify(record[key])}`,
+  );
+  return `{${parts.join(',')}}`;
+}
+
+/**
+ * Stable content digest (sha256 hex of {@link stableStringify}). Exported for
+ * B1 replay, which digests the candidate's live request the same way so a
+ * `request-hash` match is well-defined.
+ */
+export function digest(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+/**
+ * Normalize a session's messages down to the deterministic, prompt-defining
+ * fields for request digesting. Volatile per-message `attrs` (model metadata,
+ * timestamps, ids) are intentionally dropped so identical prompts hash equal.
+ *
+ * NOTE (byte/file content): `bytes`/`providerFile` parts are already
+ * persistence-safe placeholders by the time a `Session` exists
+ * (`makeMessagePersistenceSafe` runs in the Session constructor), so there is
+ * nothing raw to digest here. Per round-3, v1 excludes byte/file-content runs
+ * from the replay corpus at extraction time rather than digesting bytes.
+ */
+export function normalizeMessagesForDigest(
+  messages: readonly Message[],
+): unknown {
+  return messages.map((message) => {
+    const normalized: Record<string, unknown> = {
+      type: message.type,
+      content: message.content,
+    };
+    if (message.toolCalls !== undefined) {
+      normalized.toolCalls = message.toolCalls;
+    }
+    if (message.type === 'tool_result' && message.toolCallId !== undefined) {
+      normalized.toolCallId = message.toolCallId;
+    }
+    if (message.structuredContent !== undefined) {
+      normalized.structuredContent = message.structuredContent;
+    }
+    return normalized;
+  });
+}
+
+export interface RecorderModelInput {
+  /** Graph path of the node that issued the call; scopes `callIndex`. */
+  nodePath: string;
+  /** Provider identity: 'assistant' | 'codex' | 'claude' | ... */
+  provider: string;
+  /** Session whose messages form the model input (the prompt). */
+  requestSession: Session<any>;
+  /**
+   * Per-provider request metadata folded into the digest and (at `full`) the
+   * stored request: assistant threads its resolved LLMOptions manifest (system,
+   * params, `toolDefsDigest`); Codex/Claude thread their turn/provider config.
+   */
+  requestMeta?: unknown;
+  /** ModelOutput-shaped response (opaque to the store). */
+  response: unknown;
+}
+
+export interface RecorderToolInput {
+  /** Graph path of the tools node; scopes `callIndex`. */
+  nodePath: string;
+  toolName: string;
+  /** Parsed tool arguments — digested always, stored only at `full`. */
+  input: unknown;
+  /** CallToolResult-shaped result (opaque to the store). */
+  result: unknown;
+  /** Declared effect metadata, if any. */
+  effect?: unknown;
+}
+
+export interface RecorderNodeInput {
+  nodePath: string;
+  nodeType: string;
+  branch?: string;
+}
+
+/**
+ * Per-run capture handle. All three emit methods assign `seq` synchronously (so
+ * order is fixed even when the caller does not await) and enqueue the append on
+ * a fire-ordered promise chain — appends never reorder. Call {@link drain} at a
+ * terminal boundary (completion/suspension) to flush pending appends.
+ */
+export interface Recorder {
+  readonly level: RecordLevel;
+  /**
+   * Path of the node currently executing; set on each node entry and used as a
+   * fallback nodePath for model/tool calls that do not thread one explicitly
+   * (e.g. structured/parallel model calls via `executeSource`).
+   */
+  currentNodePath?: string;
+  node(input: RecorderNodeInput): void;
+  model(input: RecorderModelInput): void;
+  tool(input: RecorderToolInput): void;
+  /** Await all pending appends. */
+  drain(): Promise<void>;
+}
+
+export interface CreateRecorderOptions {
+  level: Exclude<RecordLevel, 'off'>;
+  /**
+   * Highest `seq` already present in the run's recording (recording spans
+   * resumes). The next assigned seq is `initialSeq + 1`; pass `-1` for a fresh
+   * run so the first seq is `0`.
+   */
+  initialSeq: number;
+  /** Append sink — the store's (fenced) `appendRecord` for this run. */
+  append: (entry: RunRecordEntry) => Promise<void>;
+  /** Injected clock for record timestamps (defaults to the app's `now`). */
+  now?: () => number;
+}
+
+/**
+ * Highest seq currently present in a run's recording stream, or `-1` when the
+ * stream is empty/absent. Used to seed {@link createRunRecorder} so seq stays
+ * monotonic across suspend/resume.
+ */
+export function maxRecordSeq(
+  recording: readonly RunRecordEntry[] | undefined,
+): number {
+  let max = -1;
+  for (const entry of recording ?? []) {
+    if (entry.record.seq > max) {
+      max = entry.record.seq;
+    }
+  }
+  return max;
+}
+
+export function createRunRecorder(options: CreateRecorderOptions): Recorder {
+  const now = options.now ?? Date.now;
+  const level = options.level;
+  const full = level === 'full';
+  let seq = options.initialSeq;
+  const modelCallIndex = new Map<string, number>();
+  const toolCallIndex = new Map<string, number>();
+  // Fire-ordered append chain: appends are enqueued in seq order and never
+  // reorder. A per-append catch keeps the chain alive on a transient store
+  // error (recording is opt-in/best-effort and must not fail the run).
+  let chain: Promise<void> = Promise.resolve();
+
+  const enqueue = (entry: RunRecordEntry): void => {
+    chain = chain.then(() =>
+      options.append(entry).catch((error) => {
+        console.warn(
+          `Recording append failed for seq ${entry.record.seq}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }),
+    );
+  };
+
+  const nextCallIndex = (
+    map: Map<string, number>,
+    nodePath: string,
+  ): number => {
+    const index = map.get(nodePath) ?? 0;
+    map.set(nodePath, index + 1);
+    return index;
+  };
+
+  const recorder: Recorder = {
+    level,
+    currentNodePath: undefined,
+    node(input) {
+      const record: NodeBreadcrumb = {
+        seq: ++seq,
+        nodePath: input.nodePath,
+        nodeType: input.nodeType,
+        at: now(),
+      };
+      if (input.branch !== undefined) {
+        record.branch = input.branch;
+      }
+      enqueue({ kind: 'node', record });
+    },
+    model(input) {
+      const normalizedRequest = {
+        messages: normalizeMessagesForDigest(input.requestSession.messages),
+        meta: input.requestMeta ?? null,
+      };
+      const requestDigest = digest({
+        provider: input.provider,
+        request: normalizedRequest,
+      });
+      const record: ModelCallRecord = {
+        seq: ++seq,
+        nodePath: input.nodePath,
+        callIndex: nextCallIndex(modelCallIndex, input.nodePath),
+        provider: input.provider,
+        requestDigest,
+        response: input.response,
+        at: now(),
+      };
+      // 'decisions' drops the normalized request; digests are always recorded.
+      if (full) {
+        record.request = normalizedRequest;
+      }
+      enqueue({ kind: 'model', record });
+    },
+    tool(input) {
+      const argsDigest = digest(input.input);
+      const record: ToolCallRecord = {
+        seq: ++seq,
+        nodePath: input.nodePath,
+        callIndex: nextCallIndex(toolCallIndex, input.nodePath),
+        toolName: input.toolName,
+        argsDigest,
+        result: input.result,
+        at: now(),
+      };
+      // 'decisions' drops the parsed input; digests are always recorded.
+      if (full) {
+        record.input = input.input;
+      }
+      if (input.effect !== undefined) {
+        record.effect = input.effect;
+      }
+      enqueue({ kind: 'tool', record });
+    },
+    drain() {
+      return chain;
+    },
+  };
+  return recorder;
+}

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -450,6 +450,11 @@ export class RandomSource extends StringSource {
   }
 
   async getContent(_session: Session<any>): Promise<string> {
+    // B1 TODO (determinism inventory, Appendix B0 round-3): direct Math.random
+    // here (and Date.now at the LlmSource instanceId below) is not yet pinned by
+    // a RuntimeRng/RuntimeClock. B0 injects a clock only where RECORDS need
+    // timestamps; banning direct Date.now/Math.random on replay-critical paths
+    // (source.ts, plus the eventScopeId seed in graph_executor) is B1 scope.
     const randomIndex = Math.floor(Math.random() * this.contentList.length);
     return this.contentList[randomIndex];
   }

--- a/packages/core/src/templates/primitives/claude_turn.ts
+++ b/packages/core/src/templates/primitives/claude_turn.ts
@@ -215,6 +215,28 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
     }
     const sessionResult = this.prepareSessionResult(result);
 
+    // B0 model capture (Appendix B0 work item 4). Claude uses its own normalizer:
+    // the TurnModelRequest session + provider config digest, provider = 'claude'.
+    // One record per wrapModelCall invocation (internal vendor rounds aggregate
+    // into `sessionResult`). Faithful raw replay needs retain: 'full'.
+    const claudeRecorder = runtime?.recorder;
+    if (claudeRecorder) {
+      claudeRecorder.model({
+        nodePath:
+          options.nodePath ?? claudeRecorder.currentNodePath ?? 'claudeTurn',
+        provider: 'claude',
+        requestSession: modelSession,
+        requestMeta: {
+          model: this.options.model,
+          cwd: this.options.cwd,
+          permissionMode: this.options.permissionMode,
+          allowedTools: this.options.allowedTools,
+          disallowedTools: this.options.disallowedTools,
+        },
+        response: sessionResult,
+      });
+    }
+
     let nextSession: Session<TVars>;
     if (this.options.squashWith) {
       nextSession = await this.options.squashWith(currentSession, result);

--- a/packages/core/src/templates/primitives/codex_turn.ts
+++ b/packages/core/src/templates/primitives/codex_turn.ts
@@ -281,6 +281,27 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
     }
     const sessionResult = this.prepareSessionResult(result);
 
+    // B0 model capture (Appendix B0 work item 4). Codex uses its own normalizer:
+    // the TurnModelRequest session + provider config digest, provider = 'codex'.
+    // One record per wrapModelCall invocation (internal vendor rounds aggregate
+    // into `sessionResult`). Faithful raw replay needs retain: 'full'.
+    const codexRecorder = runtime?.recorder;
+    if (codexRecorder) {
+      codexRecorder.model({
+        nodePath:
+          options.nodePath ?? codexRecorder.currentNodePath ?? 'codexTurn',
+        provider: 'codex',
+        requestSession: modelSession,
+        requestMeta: {
+          model: this.options.model,
+          cwd: this.options.cwd,
+          sandboxPolicy: this.options.sandboxPolicy,
+          approvalPolicy: this.options.approvalPolicy,
+        },
+        response: sessionResult,
+      });
+    }
+
     let nextSession: Session<TVars>;
     if (this.options.squashWith) {
       nextSession = await this.options.squashWith(currentSession, result);

--- a/packages/core/src/templates/primitives/model_runtime.ts
+++ b/packages/core/src/templates/primitives/model_runtime.ts
@@ -11,6 +11,26 @@ import type { Vars } from '../../session';
 
 export interface ModelRuntimeRequest<TVars extends Vars = Vars> {
   session: Session<TVars>;
+  /**
+   * Resolved LLMOptions manifest (system, params, `toolDefsDigest`) threaded in
+   * by the assistant node so the B0 recording (and any `wrapModelCall`
+   * middleware) can digest the FULL provider request, not just the session
+   * (round-3: `ModelRuntimeRequest` is otherwise `{ session }` only, which would
+   * make request-hash keying unsound). Absent for callers that do not resolve a
+   * source manifest (e.g. structured/parallel model calls).
+   */
+  requestMeta?: unknown;
+}
+
+/**
+ * Per-provider recording metadata for the assistant model funnel (Appendix B0).
+ * Provider is 'assistant' here; Codex/Claude turns record separately with their
+ * own normalizers.
+ */
+export interface ModelCallRecordOptions {
+  nodePath?: string;
+  provider?: string;
+  requestMeta?: unknown;
 }
 
 export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
@@ -18,6 +38,7 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
   session: Session<TVars>,
   call: (session: Session<TVars>) => Promise<TResult>,
   commandScope = 'Model execution',
+  record?: ModelCallRecordOptions,
 ): Promise<{ session: Session<TVars>; result: TResult }> {
   const beforeModel = await runRuntimeExecutionPhase(runtime, {
     phase: 'beforeModel',
@@ -28,6 +49,7 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
 
   const request: ModelRuntimeRequest<TVars> = {
     session: validSession,
+    requestMeta: record?.requestMeta,
   };
   const prepared = await runExecutionPhase({
     phase: 'prepareModelInput',
@@ -68,7 +90,7 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
       >(runtime, {
         phase: 'wrapModelCall',
         session: validSession,
-        request: { session: modelSession },
+        request: { session: modelSession, requestMeta: record?.requestMeta },
         call: async ({ request }) => {
           if (await emitModelEvent(runtime, 'model.started')) {
             openModelEvents++;
@@ -95,6 +117,21 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
   assertModelCommandSupported(afterModel.command, commandScope);
   validSession = afterModel.session;
   result = (afterModel.result ?? result) as TResult;
+
+  // B0 model capture at the wrapModelCall boundary (Appendix B0 work item 4).
+  // One ModelCallRecord per invocation (node-output granularity: internal
+  // vendor rounds inside the `call` are aggregated into this single response).
+  // provider = 'assistant'; Codex/Claude turns record with their own
+  // normalizers. `modelSession` is the input sent to the provider; `requestMeta`
+  // is the resolved-LLMOptions manifest threaded in by the assistant node.
+  runtime.recorder?.model({
+    nodePath:
+      record?.nodePath ?? runtime.recorder.currentNodePath ?? commandScope,
+    provider: record?.provider ?? 'assistant',
+    requestSession: modelSession,
+    requestMeta: record?.requestMeta,
+    response: result,
+  });
 
   return { session: validSession, result };
 }

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -132,7 +132,23 @@ export async function executePromptTrailTool<TInput, TResult>(
             () => tool.execute(parsedInput, toolContext),
           )
         : await tool.execute(parsedInput, toolContext);
-    return toolResultToCallToolResult(result);
+    const callResult = toolResultToCallToolResult(result);
+    // B0 tool capture at the single execution funnel (Appendix B0 work item 1).
+    // Recorded only when a recorder + nodePath were threaded in — i.e. the graph
+    // tools node (and graph ai-sdk-wrapped tools). Builtin/MCP/vendor-loop tool
+    // calls execute provider-side outside this funnel and are reconstructed from
+    // the model response, so they carry no recorder and are not double-recorded.
+    context.recorder?.tool({
+      nodePath:
+        context.recordNodePath ??
+        context.recorder.currentNodePath ??
+        executionName,
+      toolName: executionName,
+      input: parsedInput,
+      result: callResult,
+      effect: executionContext.effect,
+    });
+    return callResult;
   } catch (error) {
     return {
       content: [{ type: 'text', text: formatToolError(error) }],


### PR DESCRIPTION
Completes B0 on top of the storage half (#68). A checkpoint run with recording:'decisions'|'full' now leaves a seq-ordered stream of node breadcrumbs, model call records (per-provider normalized request digests), and tool call records — the corpus + golden source for B1 positional replay and the eventual replay-diff deploy gate.

Design compliance with the round-2/3 code-verified corrections: three normalizers not one; node-output granularity; parallel/loop handled by seq order; vendor/builtin/MCP tool calls captured via the model response; no bytesDigest; recorder clock from the app's injectable now.

11 new recording tests (ordered stream shape, level semantics, cross-resume seq continuity, digest stability across identical runs, lease-fenced appends, codex-turn capture via the fake client). core 768 unit / claw 36 / stores unchanged green / build+lint+prettier clean. Includes a stray unused-import lint fix in claw's supervisor test.