### PR TITLE
feat: @prompttrail/telegram (claw roadmap #6 — second channel)

### DIFF
--- a/claw/.env.example
+++ b/claw/.env.example
@@ -1,3 +1,5 @@
+# Claw boots with Discord, Telegram, or both. At least one of DISCORD_TOKEN or
+# TELEGRAM_TOKEN must be set (fail-fast when neither is present).
 DISCORD_TOKEN=
 
 # Comma-separated channel names or ids where the bot may respond.
@@ -8,6 +10,17 @@ DISCORD_ALLOWED_CHANNELS=general
 DISCORD_REQUIRE_MENTION=false
 DISCORD_FREE_RESPONSE_CHANNELS=general
 DISCORD_THREAD_REQUIRE_MENTION=false
+
+# --- Telegram channel (optional) --------------------------------------------
+# Bot token from @BotFather. When set, claw adds a Telegram gateway parallel to
+# Discord using the same dispatch/skills agent.
+TELEGRAM_TOKEN=
+# Comma-separated chat ids (numeric) or @usernames the bot may process. Empty =
+# any chat.
+TELEGRAM_ALLOWED_CHATS=
+# true: require an @botusername mention in group chats (stripped from the input);
+# DMs never require a mention.
+TELEGRAM_REQUIRE_MENTION=false
 
 # echo is useful for checking Discord registration/token/intents first.
 # openai uses ai-sdk and requires OPENAI_API_KEY plus CLAW_OPENAI_MODEL.

--- a/claw/README.md
+++ b/claw/README.md
@@ -1,8 +1,16 @@
-# Claw Discord Bot
+# Claw Bot
 
-Claw is a dogfooding Discord bot for the PromptTrail runtime bindings work. It
-uses the real `PromptTrail.app(...).on(discord.messages(), ...)` API and a real
-`discord.js` gateway client.
+Claw is a dogfooding bot for the PromptTrail runtime bindings work. It uses the
+real `PromptTrail.app(...).on(discord.messages(), ...)` API and a real
+`discord.js` gateway client, and — as the second channel that validates
+`runtime_bindings` is not Discord-shaped — an optional `telegram.messages()`
+binding backed by `@prompttrail/telegram`'s dependency-free long-polling client.
+
+Claw boots with **Discord, Telegram, or both**. Set `DISCORD_TOKEN`,
+`TELEGRAM_TOKEN`, or both; startup fails fast only when neither is present. Both
+channels share the same dispatch/skills agent — a message from either platform
+routes to the same `main` agent, with the conversation id derived from the
+platform's own `sessionKey`.
 
 ## Setup
 
@@ -69,6 +77,29 @@ The bot uses these binding defaults:
 
 This is intentionally close to the Hermes-style scenario in
 `design-docs/runtime-bindings-discord-cron.md`.
+
+## Telegram channel
+
+Set `TELEGRAM_TOKEN` (a bot token from [@BotFather](https://t.me/BotFather)) to
+add a Telegram gateway. `@prompttrail/telegram` implements the same generic
+`RuntimeAdapter` contract as `@prompttrail/discord` with no heavy SDK — it talks
+to the Bot API over plain HTTPS long-polling (`getUpdates`) using the global
+`fetch` on Node 22+.
+
+- Conversations key on the chat id via `telegram.sessionKey({ groupSessionsPerUser: true })`:
+  DMs are naturally per-user; group chats get one conversation per user.
+- `TELEGRAM_ALLOWED_CHATS` (comma-separated numeric ids or `@usernames`, empty =
+  any) restricts which chats the bot processes.
+- `TELEGRAM_REQUIRE_MENTION=true` requires an `@botusername` mention in group
+  chats and strips it from the input; DMs never require a mention.
+- Replies go back to the originating chat (`telegram.replyToChat()`), threaded to
+  the source message in groups, and are chunked to Telegram's 4096-char limit.
+
+```bash
+TELEGRAM_TOKEN=...
+TELEGRAM_ALLOWED_CHATS=
+TELEGRAM_REQUIRE_MENTION=false
+```
 
 ## Skills (Phase 0)
 

--- a/claw/package.json
+++ b/claw/package.json
@@ -15,6 +15,7 @@
     "@prompttrail/core": "workspace:*",
     "@prompttrail/cron": "workspace:*",
     "@prompttrail/discord": "workspace:*",
+    "@prompttrail/telegram": "workspace:*",
     "@prompttrail/store-sqlite": "workspace:*",
     "better-sqlite3": "^12.10.0",
     "dotenv": "^17.4.2"

--- a/claw/src/index.ts
+++ b/claw/src/index.ts
@@ -4,7 +4,9 @@ import { join } from 'node:path';
 import { Agent, PromptTrail, Source } from '@prompttrail/core';
 import { cron, cronGateway } from '@prompttrail/cron';
 import { discord, discordGateway } from '@prompttrail/discord';
+import { telegram, telegramGateway } from '@prompttrail/telegram';
 import { SqliteRunStore } from '@prompttrail/store-sqlite';
+import { resolveClawTokens } from './runtime-tokens.js';
 import {
   createAuthorSkill,
   createClawSkillAgent,
@@ -27,11 +29,14 @@ import {
 } from './skills/index.js';
 
 interface ClawConfig {
-  token: string;
+  discordToken?: string;
+  telegramToken?: string;
   allowedChannels: string[];
   freeResponseChannels: string[];
   requireMention: boolean;
   threadRequireMention: boolean;
+  telegramAllowedChats: string[];
+  telegramRequireMention: boolean;
   replyMode: 'echo' | 'openai' | 'codex';
   openaiModel?: string;
   codexAppServerUrl: string;
@@ -177,28 +182,47 @@ if (supervisorCron) {
     );
 }
 
-runtime.on(discord.messages(), (binding) =>
-  binding
-    .where(discord.notBot())
-    .toAgent('main')
-    .conversation(
-      discord.sessionKey({
-        groupSessionsPerUser: true,
-        threadSessionsPerUser: false,
+// Discord channel (opt-in via DISCORD_TOKEN).
+if (config.discordToken) {
+  runtime.on(discord.messages(), (binding) =>
+    binding
+      .where(discord.notBot())
+      .toAgent('main')
+      .conversation(
+        discord.sessionKey({
+          groupSessionsPerUser: true,
+          threadSessionsPerUser: false,
+        }),
+      )
+      .reply(discord.replyToOriginThread())
+      .defaults({
+        behavior: {
+          allowedChannels: config.allowedChannels,
+          freeResponseChannels: config.freeResponseChannels,
+          requireMention: config.requireMention,
+          threadRequireMention: config.threadRequireMention,
+          autoThread: false,
+        },
+        toolsets: ['discord'],
       }),
-    )
-    .reply(discord.replyToOriginThread())
-    .defaults({
-      behavior: {
-        allowedChannels: config.allowedChannels,
-        freeResponseChannels: config.freeResponseChannels,
-        requireMention: config.requireMention,
-        threadRequireMention: config.threadRequireMention,
-        autoThread: false,
-      },
-      toolsets: ['discord'],
-    }),
-);
+  );
+}
+
+// Telegram channel (opt-in via TELEGRAM_TOKEN). Parallel to the Discord
+// binding: same dispatch/skills agent, conversation key via telegram.sessionKey.
+// Chat allowlist + mention gating live on the gateway (see telegramGateway).
+if (config.telegramToken) {
+  runtime.on(telegram.messages(), (binding) =>
+    binding
+      .where(telegram.notBot())
+      .toAgent('main')
+      .conversation(telegram.sessionKey({ groupSessionsPerUser: true }))
+      .reply(telegram.replyToChat())
+      .defaults({
+        toolsets: ['telegram'],
+      }),
+  );
+}
 const bundle = runtime.bundle('claw-discord');
 
 const server = PromptTrail.server({
@@ -208,21 +232,55 @@ const server = PromptTrail.server({
   errorMessage: 'Claw failed to handle that message.',
   adapters: [
     ...(supervisorCron ? [cronGateway()] : []),
-    discordGateway({
-      token: config.token,
-      stripBotMention: true,
-      onReady(readyClient) {
-        console.log(`Claw Discord bot logged in as ${readyClient.user.tag}`);
-        console.log(`Allowed channels: ${config.allowedChannels.join(', ')}`);
-        console.log(`Reply mode: ${config.replyMode}`);
-        console.log(
-          `Skills: ${registry
-            .listEnabled()
-            .map((row) => row.id)
-            .join(', ')}`,
-        );
-      },
-    }),
+    ...(config.discordToken
+      ? [
+          discordGateway({
+            token: config.discordToken,
+            stripBotMention: true,
+            onReady(readyClient) {
+              console.log(
+                `Claw Discord bot logged in as ${readyClient.user.tag}`,
+              );
+              console.log(
+                `Allowed channels: ${config.allowedChannels.join(', ')}`,
+              );
+              console.log(`Reply mode: ${config.replyMode}`);
+              console.log(
+                `Skills: ${registry
+                  .listEnabled()
+                  .map((row) => row.id)
+                  .join(', ')}`,
+              );
+            },
+          }),
+        ]
+      : []),
+    ...(config.telegramToken
+      ? [
+          telegramGateway({
+            token: config.telegramToken,
+            requireMention: config.telegramRequireMention,
+            allowedChats:
+              config.telegramAllowedChats.length > 0
+                ? config.telegramAllowedChats
+                : undefined,
+            onReady(me) {
+              console.log(
+                `Claw Telegram bot logged in as @${me.username ?? me.id}`,
+              );
+              console.log(
+                config.telegramAllowedChats.length > 0
+                  ? `Allowed chats: ${config.telegramAllowedChats.join(', ')}`
+                  : 'Allowed chats: (any)',
+              );
+              console.log(`Reply mode: ${config.replyMode}`);
+            },
+            onError(error) {
+              console.error('Telegram poll error', error);
+            },
+          }),
+        ]
+      : []),
   ],
 });
 
@@ -303,13 +361,11 @@ function readPackageVersion(): string {
 }
 
 function readConfig(): ClawConfig {
-  const token = process.env.DISCORD_TOKEN;
-  if (!token) {
-    throw new Error('DISCORD_TOKEN is required');
-  }
+  const { discordToken, telegramToken } = resolveClawTokens(process.env);
   const requireMention = readBoolean('DISCORD_REQUIRE_MENTION', false);
   return {
-    token,
+    discordToken,
+    telegramToken,
     allowedChannels: readList('DISCORD_ALLOWED_CHANNELS', ['general']),
     freeResponseChannels: readList(
       'DISCORD_FREE_RESPONSE_CHANNELS',
@@ -317,6 +373,8 @@ function readConfig(): ClawConfig {
     ),
     requireMention,
     threadRequireMention: readBoolean('DISCORD_THREAD_REQUIRE_MENTION', false),
+    telegramAllowedChats: readList('TELEGRAM_ALLOWED_CHATS', []),
+    telegramRequireMention: readBoolean('TELEGRAM_REQUIRE_MENTION', false),
     replyMode: readReplyMode(),
     openaiModel: readOptionalString('CLAW_OPENAI_MODEL'),
     codexAppServerUrl:

--- a/claw/src/runtime-tokens.test.ts
+++ b/claw/src/runtime-tokens.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { resolveClawTokens } from './runtime-tokens.js';
+
+describe('resolveClawTokens', () => {
+  it('accepts a Discord-only deployment', () => {
+    expect(resolveClawTokens({ DISCORD_TOKEN: 'd' })).toEqual({
+      discordToken: 'd',
+      telegramToken: undefined,
+    });
+  });
+
+  it('accepts a Telegram-only deployment', () => {
+    expect(resolveClawTokens({ TELEGRAM_TOKEN: 't' })).toEqual({
+      discordToken: undefined,
+      telegramToken: 't',
+    });
+  });
+
+  it('accepts both tokens', () => {
+    expect(
+      resolveClawTokens({ DISCORD_TOKEN: 'd', TELEGRAM_TOKEN: 't' }),
+    ).toEqual({ discordToken: 'd', telegramToken: 't' });
+  });
+
+  it('trims whitespace and treats blank tokens as absent', () => {
+    expect(() =>
+      resolveClawTokens({ DISCORD_TOKEN: '   ', TELEGRAM_TOKEN: '' }),
+    ).toThrow(/At least one of DISCORD_TOKEN or TELEGRAM_TOKEN/);
+  });
+
+  it('fails fast when neither token is present', () => {
+    expect(() => resolveClawTokens({})).toThrow(
+      /At least one of DISCORD_TOKEN or TELEGRAM_TOKEN/,
+    );
+  });
+});

--- a/claw/src/runtime-tokens.ts
+++ b/claw/src/runtime-tokens.ts
@@ -1,0 +1,27 @@
+/**
+ * Channel-token resolution for claw. Claw now boots with a Discord gateway, a
+ * Telegram gateway, or both. Fail-fast only when NEITHER token is present — a
+ * single configured channel is a valid deployment.
+ */
+export interface ClawTokens {
+  discordToken?: string;
+  telegramToken?: string;
+}
+
+export function resolveClawTokens(
+  env: Record<string, string | undefined>,
+): ClawTokens {
+  const discordToken = optional(env.DISCORD_TOKEN);
+  const telegramToken = optional(env.TELEGRAM_TOKEN);
+  if (!discordToken && !telegramToken) {
+    throw new Error(
+      'At least one of DISCORD_TOKEN or TELEGRAM_TOKEN is required.',
+    );
+  }
+  return { discordToken, telegramToken };
+}
+
+function optional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@prompttrail/telegram",
+  "version": "0.0.1",
+  "description": "Telegram runtime package for PromptTrail",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rm -f tsconfig.tsbuildinfo && tsup && tsc --emitDeclarationOnly -p tsconfig.json",
+    "test": "vitest --run --watch=false",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest watch",
+    "lint": "cd ../.. && ./node_modules/.bin/eslint packages/telegram/src",
+    "lint:fix": "cd ../.. && ./node_modules/.bin/eslint packages/telegram/src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist coverage",
+    "prepublishOnly": "pnpm run clean && pnpm run build"
+  },
+  "dependencies": {
+    "@prompttrail/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.19",
+    "@vitest/coverage-v8": "^1.6.1",
+    "tsup": "^8.3.6",
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/packages/telegram/src/__tests__/unit/runtime_bindings_mock.test.ts
+++ b/packages/telegram/src/__tests__/unit/runtime_bindings_mock.test.ts
@@ -1,0 +1,358 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  Agent,
+  MemoryRunStore,
+  PromptTrail,
+  on,
+  type RuntimeBundle,
+} from '@prompttrail/core';
+import {
+  telegram,
+  telegramGateway,
+  type TelegramGatewayOptions,
+} from '../../index';
+import { FakeTelegramClient } from '../../testing';
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  { timeout = 3_000, interval = 5 } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  throw new Error('waitFor timed out');
+}
+
+function echoAgent(name = 'main'): Agent {
+  return Agent.create(name)
+    .inbox('inbox')
+    .assistant('reply', (session) => ({
+      content: `reply:${session.getLastMessage()?.content ?? ''}`,
+    }));
+}
+
+const started: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  while (started.length > 0) {
+    await started.pop()?.stop();
+  }
+});
+
+interface FixtureConfig {
+  bundle: (main: Agent) => RuntimeBundle;
+  gateway?: Partial<TelegramGatewayOptions>;
+}
+
+async function startFixture(config: FixtureConfig) {
+  const client = new FakeTelegramClient();
+  const store = new MemoryRunStore();
+  const main = echoAgent('main');
+  const app = PromptTrail.app({ store, agents: { main } });
+  const bundle = config.bundle(main);
+  const server = PromptTrail.server({
+    bundle,
+    runtime: app,
+    presence: { kind: 'typing' },
+    adapters: [
+      telegramGateway({ token: 'test-token', client, ...config.gateway }),
+    ],
+  });
+  await server.start();
+  started.push(server);
+
+  const conversationIds = async () =>
+    [...(await store.entries())].map(([id]) => id);
+  const inbox = async (id: string) => {
+    const run = await store.get(id);
+    return (run?.inbox ?? []).map((message) => ({
+      role: message.kind,
+      content: message.content,
+    }));
+  };
+
+  return { client, store, server, conversationIds, inbox };
+}
+
+function bundleWith(bindings: unknown[]): (main: Agent) => RuntimeBundle {
+  return (main) =>
+    PromptTrail.runtimeBundle({
+      name: 'telegram-test',
+      agents: { main },
+      defaults: { checkpoint: true },
+      bindings: bindings as never,
+    });
+}
+
+const routedBinding = () =>
+  on(telegram.messages())
+    .where(telegram.notBot())
+    .toAgent('main')
+    .conversation(telegram.sessionKey({ groupSessionsPerUser: true }))
+    .reply(telegram.replyToChat());
+
+describe('runtime bindings with a fake Telegram client', () => {
+  it('routes an allowed private message to a durable agent conversation', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: 555,
+      text: 'why is the VM out of disk?',
+      fromUsername: 'alice',
+    });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    expect(await fixture.conversationIds()).toContain('telegram:chat:555');
+    expect(await fixture.inbox('telegram:chat:555')).toContainEqual(
+      expect.objectContaining({
+        role: 'user',
+        content: 'why is the VM out of disk?',
+      }),
+    );
+    expect(fixture.client.sent).toContainEqual(
+      expect.objectContaining({
+        chatId: '555',
+        text: 'reply:why is the VM out of disk?',
+        replyToMessageId: undefined,
+      }),
+    );
+  });
+
+  it('isolates two users in a group when groupSessionsPerUser is set', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 1,
+      fromUsername: 'alice',
+      text: 'alice task',
+    });
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 2,
+      fromUsername: 'bob',
+      text: 'bob task',
+    });
+
+    await waitFor(() => fixture.client.sent.length >= 2);
+
+    const ids = await fixture.conversationIds();
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'telegram:chat:-100:user:1',
+        'telegram:chat:-100:user:2',
+      ]),
+    );
+  });
+
+  it('shares a group conversation when groupSessionsPerUser is not set', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([
+        on(telegram.messages())
+          .where(telegram.notBot())
+          .toAgent('main')
+          .conversation(telegram.sessionKey())
+          .reply(telegram.replyToChat()),
+      ]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 1,
+      fromUsername: 'alice',
+      text: 'first',
+    });
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 2,
+      fromUsername: 'bob',
+      text: 'second',
+    });
+
+    await waitFor(() => fixture.client.sent.length >= 2);
+
+    expect(await fixture.conversationIds()).toEqual(['telegram:chat:-100']);
+  });
+
+  it('keeps DMs isolated per chat', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: 111,
+      fromUsername: 'alice',
+      text: 'hi',
+    });
+    fixture.client.pushUpdate({ chatId: 222, fromUsername: 'bob', text: 'yo' });
+
+    await waitFor(() => fixture.client.sent.length >= 2);
+
+    const ids = await fixture.conversationIds();
+    expect(ids).toEqual(
+      expect.arrayContaining(['telegram:chat:111', 'telegram:chat:222']),
+    );
+  });
+
+  it('drops bot-authored messages via the notBot filter', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: 555,
+      text: 'automated status',
+      fromUsername: 'digestBot',
+      isBot: true,
+    });
+    // A subsequent human message must still route, proving the loop kept going.
+    fixture.client.pushUpdate({
+      chatId: 555,
+      text: 'human here',
+      fromUsername: 'alice',
+    });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    expect(fixture.client.sent).toEqual([
+      expect.objectContaining({ text: 'reply:human here' }),
+    ]);
+  });
+
+  it('respects the allowedChats gateway option', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+      gateway: { allowedChats: [555] },
+    });
+
+    fixture.client.pushUpdate({ chatId: 999, text: 'from elsewhere' });
+    fixture.client.pushUpdate({ chatId: 555, text: 'from allowed' });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    expect(fixture.client.sent).toEqual([
+      expect.objectContaining({ chatId: '555', text: 'reply:from allowed' }),
+    ]);
+  });
+
+  it('routes only chats named by the inChats filter', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([
+        on(telegram.messages())
+          .where(telegram.notBot())
+          .where(telegram.inChats([555]))
+          .toAgent('main')
+          .conversation(telegram.sessionKey())
+          .reply(telegram.replyToChat()),
+      ]),
+    });
+
+    fixture.client.pushUpdate({ chatId: 777, text: 'ignored' });
+    fixture.client.pushUpdate({ chatId: 555, text: 'accepted' });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    expect(fixture.client.sent).toEqual([
+      expect.objectContaining({ chatId: '555', text: 'reply:accepted' }),
+    ]);
+  });
+
+  it('requires and strips an @botusername mention in groups', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+      gateway: { requireMention: true },
+    });
+
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 1,
+      fromUsername: 'alice',
+      text: 'quiet background message',
+    });
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 1,
+      fromUsername: 'alice',
+      text: '@clawbot please inspect this',
+    });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    // Only the mentioned message routes, and the mention is stripped.
+    expect(fixture.client.sent).toEqual([
+      expect.objectContaining({ text: 'reply:please inspect this' }),
+    ]);
+  });
+
+  it('sets reply_to_message_id for group replies', async () => {
+    const fixture = await startFixture({
+      bundle: bundleWith([routedBinding()]),
+    });
+
+    fixture.client.pushUpdate({
+      chatId: -100,
+      chatType: 'supergroup',
+      fromId: 1,
+      fromUsername: 'alice',
+      messageId: 4242,
+      text: 'ping',
+    });
+
+    await waitFor(() => fixture.client.sent.length > 0);
+
+    expect(fixture.client.sent[0]).toEqual(
+      expect.objectContaining({ chatId: '-100', replyToMessageId: 4242 }),
+    );
+  });
+
+  it('chunks assistant replies longer than 4096 characters', async () => {
+    const longAgent = Agent.create('main')
+      .inbox('inbox')
+      .assistant('reply', () => ({ content: 'x'.repeat(5000) }));
+    const client = new FakeTelegramClient();
+    const store = new MemoryRunStore();
+    const app = PromptTrail.app({ store, agents: { main: longAgent } });
+    const bundle = PromptTrail.runtimeBundle({
+      name: 'telegram-chunk',
+      agents: { main: longAgent },
+      defaults: { checkpoint: true },
+      bindings: [
+        on(telegram.messages())
+          .toAgent('main')
+          .conversation(telegram.sessionKey())
+          .reply(telegram.replyToChat()),
+      ],
+    });
+    const server = PromptTrail.server({
+      bundle,
+      runtime: app,
+      adapters: [telegramGateway({ token: 'test-token', client })],
+    });
+    await server.start();
+    started.push(server);
+
+    client.pushUpdate({ chatId: 42, text: 'go' });
+
+    await waitFor(() => client.sent.length >= 2);
+
+    expect(client.sent).toHaveLength(2);
+    expect(client.sent[0].text.length).toBe(4096);
+    expect(client.sent[1].text.length).toBe(904);
+    expect(client.sent[0].text + client.sent[1].text).toBe('x'.repeat(5000));
+  });
+});

--- a/packages/telegram/src/__tests__/unit/telegram_gateway.test.ts
+++ b/packages/telegram/src/__tests__/unit/telegram_gateway.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  RuntimeGatewayContext,
+  RuntimeGatewayDriver,
+} from '@prompttrail/core/runtime_server';
+import {
+  chunkTelegramMessage,
+  telegram,
+  telegramGateway,
+  telegramMessageToEvent,
+  TELEGRAM_MAX_MESSAGE_LENGTH,
+  type TelegramEvent,
+} from '../../index';
+import { FakeTelegramClient } from '../../testing';
+
+function messagesGateway(
+  adapter: ReturnType<typeof telegramGateway>,
+): RuntimeGatewayDriver {
+  const gateway = adapter.gateways?.find(
+    (candidate) => candidate.type === 'telegram.messages',
+  );
+  if (!gateway) {
+    throw new Error('telegram.messages gateway not found');
+  }
+  return gateway;
+}
+
+function collectingContext(): {
+  ctx: RuntimeGatewayContext<TelegramEvent>;
+  emitted: Array<{ event: TelegramEvent; content?: string }>;
+} {
+  const emitted: Array<{ event: TelegramEvent; content?: string }> = [];
+  const ctx: RuntimeGatewayContext<TelegramEvent> = {
+    async emit(event, options) {
+      emitted.push({ event, content: options?.content });
+    },
+    bindings: [],
+  };
+  return { ctx, emitted };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  { timeout = 2_000, interval = 5 } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  throw new Error('waitFor timed out');
+}
+
+describe('chunkTelegramMessage', () => {
+  it('returns an empty array for empty content', () => {
+    expect(chunkTelegramMessage('')).toEqual([]);
+  });
+
+  it('returns a single chunk under the limit', () => {
+    expect(chunkTelegramMessage('hello')).toEqual(['hello']);
+  });
+
+  it('splits content longer than the limit', () => {
+    const text = 'a'.repeat(TELEGRAM_MAX_MESSAGE_LENGTH + 10);
+    const chunks = chunkTelegramMessage(text);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].length).toBe(TELEGRAM_MAX_MESSAGE_LENGTH);
+    expect(chunks.join('')).toBe(text);
+  });
+
+  it('prefers a newline boundary within the window', () => {
+    const head = 'a'.repeat(4000);
+    const tail = 'b'.repeat(200);
+    const chunks = chunkTelegramMessage(`${head}\n${tail}`);
+    expect(chunks).toEqual([head, tail]);
+  });
+});
+
+describe('telegramMessageToEvent', () => {
+  it('maps a group message and detects a mention', () => {
+    const event = telegramMessageToEvent(
+      {
+        message_id: 7,
+        from: { id: 9, is_bot: false, username: 'alice' },
+        chat: { id: -100, type: 'supergroup', username: 'lab' },
+        text: 'hey @clawbot',
+      },
+      'clawbot',
+    );
+    expect(event).toMatchObject({
+      source: 'telegram',
+      chatId: '-100',
+      chatType: 'supergroup',
+      chatUsername: 'lab',
+      userId: '9',
+      username: 'alice',
+      messageId: 7,
+      isGroup: true,
+      isBot: false,
+      mentionsBot: true,
+    });
+  });
+
+  it('ignores non-text updates', () => {
+    expect(
+      telegramMessageToEvent({
+        message_id: 1,
+        chat: { id: 1, type: 'private' },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('telegram trigger delivery resolution', () => {
+  it('anchors group replies to the origin message and leaves DMs unthreaded', () => {
+    const trigger = telegram.messages();
+    const groupEvent: TelegramEvent = {
+      source: 'telegram',
+      chatId: '-100',
+      chatType: 'supergroup',
+      userId: '1',
+      messageId: 55,
+      content: 'hi',
+      isGroup: true,
+      isBot: false,
+    };
+    const dmEvent: TelegramEvent = {
+      ...groupEvent,
+      chatId: '9',
+      chatType: 'private',
+      messageId: 7,
+      isGroup: false,
+    };
+    expect(
+      trigger.resolveDelivery?.(telegram.replyToChat(), groupEvent),
+    ).toEqual({ platform: 'telegram', chatId: '-100', replyToMessageId: 55 });
+    expect(trigger.resolveDelivery?.(telegram.replyToChat(), dmEvent)).toEqual({
+      platform: 'telegram',
+      chatId: '9',
+      replyToMessageId: undefined,
+    });
+  });
+});
+
+describe('telegram poll loop', () => {
+  it('emits parked updates once pushed', async () => {
+    const client = new FakeTelegramClient();
+    const gateway = messagesGateway(telegramGateway({ token: 't', client }));
+    const { ctx, emitted } = collectingContext();
+    await gateway.start(ctx);
+
+    client.pushUpdate({ chatId: 5, text: 'hello' });
+    await waitFor(() => emitted.length > 0);
+
+    expect(emitted[0].event.chatId).toBe('5');
+    expect(emitted[0].content).toBe('hello');
+    await gateway.stop?.();
+  });
+
+  it('stop() aborts the poll loop with no further processing', async () => {
+    const client = new FakeTelegramClient();
+    const onReady = vi.fn();
+    const gateway = messagesGateway(
+      telegramGateway({ token: 't', client, onReady }),
+    );
+    const { ctx, emitted } = collectingContext();
+    await gateway.start(ctx);
+    expect(onReady).toHaveBeenCalledWith({ id: 1000, username: 'clawbot' });
+
+    // The loop is parked in getUpdates; stop() must resolve promptly.
+    await gateway.stop?.();
+
+    client.pushUpdate({ chatId: 5, text: 'after stop' });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(emitted).toEqual([]);
+  });
+
+  it('backs off on a poll error, reports it, and keeps polling', async () => {
+    const client = new FakeTelegramClient();
+    const onError = vi.fn();
+    const error = new Error('network down');
+    client.failNextGetUpdates(error);
+    const gateway = messagesGateway(
+      telegramGateway({
+        token: 't',
+        client,
+        onError,
+        retryDelayMs: 5,
+        maxRetryDelayMs: 20,
+      }),
+    );
+    const { ctx, emitted } = collectingContext();
+    await gateway.start(ctx);
+
+    client.pushUpdate({ chatId: 5, text: 'recovered' });
+    await waitFor(() => emitted.length > 0);
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(emitted[0].content).toBe('recovered');
+    await gateway.stop?.();
+  });
+});
+
+describe('telegram presence', () => {
+  it('sends a typing chat action when presence starts', async () => {
+    const client = new FakeTelegramClient();
+    const adapter = telegramGateway({ token: 't', client });
+    const presence = adapter.presences?.find(
+      (candidate) => candidate.platform === 'telegram',
+    );
+    const handle = await presence?.start(
+      { event: { source: 'telegram' }, delivery: { platform: 'telegram' } },
+      { platform: 'telegram', chatId: '5' },
+      { kind: 'typing' },
+    );
+    await waitFor(() => client.chatActions.length > 0);
+    expect(client.chatActions[0]).toEqual({ chatId: '5', action: 'typing' });
+    await handle?.stop();
+  });
+});

--- a/packages/telegram/src/client.ts
+++ b/packages/telegram/src/client.ts
@@ -1,0 +1,196 @@
+/**
+ * Minimal Telegram Bot API client.
+ *
+ * Telegram's Bot API is plain HTTPS: long-polling via getUpdates and message
+ * delivery via sendMessage. This client is deliberately dependency-free — it
+ * uses the global `fetch` available on Node 22+ — so the package does not pull
+ * in grammy/telegraf. The interface is injectable so tests substitute a fake
+ * connector with no network access.
+ */
+
+export type TelegramChatType = 'private' | 'group' | 'supergroup' | 'channel';
+
+export interface TelegramUser {
+  id: number;
+  is_bot: boolean;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export interface TelegramChat {
+  id: number;
+  type: TelegramChatType;
+  title?: string;
+  username?: string;
+}
+
+export interface TelegramMessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+}
+
+export interface TelegramMessage {
+  message_id: number;
+  from?: TelegramUser;
+  chat: TelegramChat;
+  date?: number;
+  text?: string;
+  entities?: TelegramMessageEntity[];
+}
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+  edited_message?: TelegramMessage;
+}
+
+export interface GetUpdatesParams {
+  offset?: number;
+  timeout?: number;
+  allowedUpdates?: readonly string[];
+  signal?: AbortSignal;
+}
+
+export interface SendMessageParams {
+  chatId: number | string;
+  text: string;
+  replyToMessageId?: number;
+}
+
+export interface SendChatActionParams {
+  chatId: number | string;
+  action: string;
+}
+
+export interface TelegramClient {
+  getMe(): Promise<TelegramUser>;
+  getUpdates(params: GetUpdatesParams): Promise<TelegramUpdate[]>;
+  sendMessage(params: SendMessageParams): Promise<TelegramMessage>;
+  sendChatAction(params: SendChatActionParams): Promise<void>;
+}
+
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}>;
+
+export interface CreateTelegramClientOptions {
+  baseUrl?: string;
+  fetch?: FetchLike;
+}
+
+export class TelegramApiError extends Error {
+  constructor(
+    readonly method: string,
+    readonly description: string | undefined,
+    readonly errorCode?: number,
+  ) {
+    super(`Telegram API ${method} failed: ${description ?? 'unknown error'}`);
+    this.name = 'TelegramApiError';
+  }
+}
+
+interface TelegramApiResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+  error_code?: number;
+}
+
+/**
+ * Create the default HTTPS client bound to a bot token. Requires a global
+ * `fetch` (Node 22+) unless one is injected via options.
+ */
+export function createTelegramClient(
+  token: string,
+  options: CreateTelegramClientOptions = {},
+): TelegramClient {
+  const baseUrl = (options.baseUrl ?? 'https://api.telegram.org').replace(
+    /\/$/,
+    '',
+  );
+  const fetchImpl = options.fetch ?? resolveGlobalFetch();
+
+  async function call<T>(
+    method: string,
+    body?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const response = await fetchImpl(`${baseUrl}/bot${token}/${method}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: body ? JSON.stringify(pruneUndefined(body)) : undefined,
+      signal,
+    });
+    const payload = (await response.json()) as TelegramApiResponse<T>;
+    if (!response.ok || !payload.ok) {
+      throw new TelegramApiError(
+        method,
+        payload.description,
+        payload.error_code,
+      );
+    }
+    return payload.result as T;
+  }
+
+  return {
+    getMe() {
+      return call<TelegramUser>('getMe');
+    },
+    getUpdates({ offset, timeout, allowedUpdates, signal }) {
+      return call<TelegramUpdate[]>(
+        'getUpdates',
+        {
+          offset,
+          timeout,
+          allowed_updates: allowedUpdates,
+        },
+        signal,
+      );
+    },
+    sendMessage({ chatId, text, replyToMessageId }) {
+      return call<TelegramMessage>('sendMessage', {
+        chat_id: chatId,
+        text,
+        reply_to_message_id: replyToMessageId,
+      });
+    },
+    async sendChatAction({ chatId, action }) {
+      await call('sendChatAction', { chat_id: chatId, action });
+    },
+  };
+}
+
+function resolveGlobalFetch(): FetchLike {
+  const candidate = (globalThis as { fetch?: unknown }).fetch;
+  if (typeof candidate !== 'function') {
+    throw new Error(
+      'Global fetch is not available. Provide options.fetch or run on Node 22+.',
+    );
+  }
+  return candidate as unknown as FetchLike;
+}
+
+function pruneUndefined(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/packages/telegram/src/index.ts
+++ b/packages/telegram/src/index.ts
@@ -1,0 +1,481 @@
+import type {
+  ConversationResolver,
+  DeliveryTarget,
+  RuntimeFilter,
+  Trigger,
+  TriggerEvent,
+} from '@prompttrail/core';
+import type {
+  RuntimeAdapter,
+  RuntimeGatewayContext,
+  RuntimePresenceHandle,
+} from '@prompttrail/core/runtime_server';
+import {
+  createTelegramClient,
+  type TelegramChatType,
+  type TelegramClient,
+  type TelegramMessage,
+  type TelegramUpdate,
+} from './client';
+
+export * from './client';
+
+/** Telegram messages cap out at 4096 UTF-16 code units. */
+export const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
+
+/** Interval between repeated `typing` chat actions (Telegram expires it ~5s). */
+export const TELEGRAM_TYPING_INTERVAL_MS = 5_000;
+
+export interface TelegramEvent extends TriggerEvent {
+  source: 'telegram';
+  chatId: string;
+  chatType: TelegramChatType;
+  chatUsername?: string;
+  userId: string;
+  username?: string;
+  firstName?: string;
+  messageId: number;
+  content: string;
+  isGroup: boolean;
+  isBot: boolean;
+  mentionsBot?: boolean;
+}
+
+export interface TelegramOriginChatDeliveryTarget extends DeliveryTarget {
+  platform: 'telegram';
+  kind: 'originChat';
+}
+
+export interface ConcreteTelegramDeliveryTarget extends DeliveryTarget {
+  platform: 'telegram';
+  chatId: string;
+  replyToMessageId?: number;
+}
+
+export interface TelegramSessionKeyOptions {
+  /**
+   * When true, group chats get one conversation per user (chatId + userId).
+   * DMs are always per-user because a private chat id is 1:1 with a user.
+   */
+  groupSessionsPerUser?: boolean;
+}
+
+export const telegram = {
+  messages(): Trigger<TelegramEvent> {
+    return {
+      type: 'telegram.messages',
+      eventAttrs: (event) => ({
+        chatId: event.chatId,
+        chatType: event.chatType,
+        userId: event.userId,
+        username: event.username,
+        messageId: event.messageId,
+      }),
+      resolveDelivery: (delivery, event) => {
+        if (
+          delivery.platform === 'origin' ||
+          isTelegramOriginChatDeliveryTarget(delivery)
+        ) {
+          return telegramOrigin(event);
+        }
+        return delivery;
+      },
+    };
+  },
+
+  notBot(): RuntimeFilter<TelegramEvent> {
+    return (event) => !event.isBot;
+  },
+
+  inChats(
+    chatIds: ReadonlyArray<string | number>,
+  ): RuntimeFilter<TelegramEvent> {
+    const allowed = chatIds.map(normalizeChatRef);
+    return (event) => allowed.some((ref) => chatRefMatches(event, ref));
+  },
+
+  sessionKey(
+    options: TelegramSessionKeyOptions = {},
+  ): ConversationResolver<TelegramEvent> {
+    return (event) => {
+      const base = `telegram:chat:${event.chatId}`;
+      if (event.isGroup && options.groupSessionsPerUser) {
+        return `${base}:user:${event.userId}`;
+      }
+      return base;
+    };
+  },
+
+  replyToChat(): TelegramOriginChatDeliveryTarget {
+    return { platform: 'telegram', kind: 'originChat' };
+  },
+};
+
+export interface TelegramGatewayOptions {
+  token: string;
+  /** Injectable client for tests; defaults to the HTTPS long-polling client. */
+  client?: TelegramClient;
+  /** Long-poll timeout in seconds passed to getUpdates (default 30). */
+  pollTimeoutSeconds?: number;
+  /** Restrict processing to these chat ids/usernames before dispatch. */
+  allowedChats?: ReadonlyArray<string | number>;
+  /** Require an @botusername mention in groups; the mention is stripped. */
+  requireMention?: boolean;
+  onError?: (error: unknown) => void;
+  onReady?: (me: { id: number; username?: string }) => void;
+  /** Initial backoff after a poll error (ms, default 1000). */
+  retryDelayMs?: number;
+  /** Maximum backoff after repeated poll errors (ms, default 30000). */
+  maxRetryDelayMs?: number;
+}
+
+export function telegramGateway(
+  options: TelegramGatewayOptions,
+): RuntimeAdapter {
+  const client = options.client ?? createTelegramClient(options.token);
+  const pollTimeoutSeconds = options.pollTimeoutSeconds ?? 30;
+  let botUsername: string | undefined;
+  let poller: TelegramPoller | undefined;
+
+  return {
+    name: 'telegram',
+    gateways: [
+      {
+        type: 'telegram.messages',
+        async start(ctx: RuntimeGatewayContext<TelegramEvent>) {
+          const me = await client.getMe();
+          botUsername = me.username;
+          options.onReady?.({ id: me.id, username: me.username });
+          poller = new TelegramPoller(client, ctx, {
+            pollTimeoutSeconds,
+            allowedChats: options.allowedChats,
+            requireMention: options.requireMention,
+            onError: options.onError,
+            retryDelayMs: options.retryDelayMs ?? 1_000,
+            maxRetryDelayMs: options.maxRetryDelayMs ?? 30_000,
+            botUsername,
+          });
+          poller.start();
+        },
+        async stop() {
+          await poller?.stop();
+          poller = undefined;
+        },
+      },
+    ],
+    deliveries: [
+      {
+        platform: 'telegram',
+        async deliver(_ctx, target, message) {
+          if (!isConcreteTelegramDeliveryTarget(target)) {
+            return undefined;
+          }
+          const chunks = chunkTelegramMessage(message.content);
+          let last: TelegramMessage | undefined;
+          for (let index = 0; index < chunks.length; index++) {
+            last = await client.sendMessage({
+              chatId: target.chatId,
+              text: chunks[index],
+              // Reply-threading only anchors the first chunk in group chats.
+              replyToMessageId:
+                index === 0 ? target.replyToMessageId : undefined,
+            });
+          }
+          if (!last) {
+            return undefined;
+          }
+          return {
+            platform: 'telegram',
+            chatId: target.chatId,
+            messageId: last.message_id,
+          };
+        },
+      },
+    ],
+    presences: [
+      {
+        platform: 'telegram',
+        start(_ctx, target, presence) {
+          if (
+            !isConcreteTelegramDeliveryTarget(target) ||
+            (presence.kind !== 'typing' && presence.kind !== 'processing')
+          ) {
+            return undefined;
+          }
+          return startTelegramTyping(client, target.chatId);
+        },
+      },
+    ],
+    observers: [],
+  };
+}
+
+interface TelegramPollerOptions {
+  pollTimeoutSeconds: number;
+  allowedChats?: ReadonlyArray<string | number>;
+  requireMention?: boolean;
+  onError?: (error: unknown) => void;
+  retryDelayMs: number;
+  maxRetryDelayMs: number;
+  botUsername?: string;
+}
+
+class TelegramPoller {
+  private readonly controller = new AbortController();
+  private readonly allowedChats?: ReadonlyArray<{
+    kind: 'id' | 'username';
+    value: string;
+  }>;
+  private running = false;
+  private loop?: Promise<void>;
+  private offset?: number;
+
+  constructor(
+    private readonly client: TelegramClient,
+    private readonly ctx: RuntimeGatewayContext<TelegramEvent>,
+    private readonly options: TelegramPollerOptions,
+  ) {
+    this.allowedChats = options.allowedChats?.map(normalizeChatRef);
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.loop = this.run();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.controller.abort();
+    // Await the loop so no getUpdates request or backoff timer outlives stop().
+    await this.loop?.catch(() => undefined);
+    this.loop = undefined;
+  }
+
+  private async run(): Promise<void> {
+    let backoff = this.options.retryDelayMs;
+    while (this.running) {
+      try {
+        const updates = await this.client.getUpdates({
+          offset: this.offset,
+          timeout: this.options.pollTimeoutSeconds,
+          allowedUpdates: ['message'],
+          signal: this.controller.signal,
+        });
+        backoff = this.options.retryDelayMs;
+        for (const update of updates) {
+          this.offset = update.update_id + 1;
+          if (!this.running) {
+            break;
+          }
+          try {
+            await this.handle(update);
+          } catch (error) {
+            this.options.onError?.(error);
+          }
+        }
+      } catch (error) {
+        if (!this.running || this.controller.signal.aborted) {
+          break;
+        }
+        this.options.onError?.(error);
+        await this.sleep(backoff);
+        backoff = Math.min(backoff * 2, this.options.maxRetryDelayMs);
+      }
+    }
+  }
+
+  private async handle(update: TelegramUpdate): Promise<void> {
+    const message = update.message;
+    if (!message) {
+      return;
+    }
+    const event = telegramMessageToEvent(message, this.options.botUsername);
+    if (!event) {
+      return;
+    }
+    if (
+      this.allowedChats &&
+      !this.allowedChats.some((ref) => chatRefMatches(event, ref))
+    ) {
+      return;
+    }
+    let content = event.content;
+    if (this.options.requireMention && event.isGroup) {
+      if (!event.mentionsBot) {
+        return;
+      }
+      content = stripMention(content, this.options.botUsername);
+    }
+    await this.ctx.emit(event, { content });
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (ms <= 0 || this.controller.signal.aborted) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        cleanup();
+        resolve();
+      };
+      const cleanup = () =>
+        this.controller.signal.removeEventListener('abort', onAbort);
+      this.controller.signal.addEventListener('abort', onAbort, {
+        once: true,
+      });
+    });
+  }
+}
+
+export function telegramMessageToEvent(
+  message: TelegramMessage,
+  botUsername?: string,
+): TelegramEvent | undefined {
+  if (typeof message.text !== 'string' || message.text.length === 0) {
+    return undefined;
+  }
+  const chat = message.chat;
+  const isGroup = chat.type === 'group' || chat.type === 'supergroup';
+  const from = message.from;
+  return {
+    source: 'telegram',
+    chatId: String(chat.id),
+    chatType: chat.type,
+    chatUsername: chat.username,
+    userId: from ? String(from.id) : String(chat.id),
+    username: from?.username,
+    firstName: from?.first_name,
+    messageId: message.message_id,
+    content: message.text,
+    isGroup,
+    isBot: from?.is_bot ?? false,
+    mentionsBot: botUsername
+      ? mentionsUsername(message.text, botUsername)
+      : false,
+  };
+}
+
+export async function startTelegramTyping(
+  client: TelegramClient,
+  chatId: string,
+): Promise<RuntimePresenceHandle | undefined> {
+  const send = () =>
+    client.sendChatAction({ chatId, action: 'typing' }).catch(() => undefined);
+  await send();
+  const interval = setInterval(() => {
+    void send();
+  }, TELEGRAM_TYPING_INTERVAL_MS);
+  return {
+    stop() {
+      clearInterval(interval);
+    },
+  };
+}
+
+/**
+ * Split content into chunks that respect Telegram's 4096-char message limit,
+ * preferring a newline boundary when one exists within the window.
+ */
+export function chunkTelegramMessage(
+  text: string,
+  limit = TELEGRAM_MAX_MESSAGE_LENGTH,
+): string[] {
+  if (text.length === 0) {
+    return [];
+  }
+  if (text.length <= limit) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    let cut = remaining.lastIndexOf('\n', limit);
+    if (cut <= 0) {
+      cut = limit;
+    }
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut).replace(/^\n/, '');
+  }
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+  return chunks;
+}
+
+export function isConcreteTelegramDeliveryTarget(
+  delivery: DeliveryTarget | undefined,
+): delivery is ConcreteTelegramDeliveryTarget {
+  return (
+    delivery?.platform === 'telegram' &&
+    'chatId' in delivery &&
+    !('kind' in delivery)
+  );
+}
+
+function isTelegramOriginChatDeliveryTarget(
+  delivery: DeliveryTarget,
+): delivery is TelegramOriginChatDeliveryTarget {
+  return delivery.platform === 'telegram' && delivery.kind === 'originChat';
+}
+
+function telegramOrigin(event: TelegramEvent): ConcreteTelegramDeliveryTarget {
+  return {
+    platform: 'telegram',
+    chatId: event.chatId,
+    replyToMessageId: event.isGroup ? event.messageId : undefined,
+  };
+}
+
+interface ChatRef {
+  kind: 'id' | 'username';
+  value: string;
+}
+
+function normalizeChatRef(ref: string | number): ChatRef {
+  if (typeof ref === 'number') {
+    return { kind: 'id', value: String(ref) };
+  }
+  const trimmed = ref.trim();
+  if (trimmed.startsWith('@')) {
+    return { kind: 'username', value: trimmed.slice(1).toLowerCase() };
+  }
+  if (/^-?\d+$/.test(trimmed)) {
+    return { kind: 'id', value: trimmed };
+  }
+  return { kind: 'username', value: trimmed.toLowerCase() };
+}
+
+function chatRefMatches(event: TelegramEvent, ref: ChatRef): boolean {
+  if (ref.kind === 'id') {
+    return event.chatId === ref.value;
+  }
+  return (event.chatUsername ?? '').toLowerCase() === ref.value;
+}
+
+function mentionsUsername(text: string, username: string): boolean {
+  return text.toLowerCase().includes(`@${username.toLowerCase()}`);
+}
+
+function stripMention(text: string, username?: string): string {
+  if (!username) {
+    return text.trim();
+  }
+  const pattern = new RegExp(`@${escapeRegExp(username)}\\b`, 'gi');
+  return text
+    .replace(pattern, ' ')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/telegram/src/testing.ts
+++ b/packages/telegram/src/testing.ts
@@ -1,0 +1,163 @@
+import type {
+  GetUpdatesParams,
+  SendChatActionParams,
+  SendMessageParams,
+  TelegramChatType,
+  TelegramClient,
+  TelegramMessage,
+  TelegramMessageEntity,
+  TelegramUpdate,
+  TelegramUser,
+} from './client';
+
+export interface FakeTelegramSentMessage {
+  chatId: number | string;
+  text: string;
+  replyToMessageId?: number;
+}
+
+export interface FakeTelegramChatAction {
+  chatId: number | string;
+  action: string;
+}
+
+export interface FakePushMessageOptions {
+  chatId: number | string;
+  text: string;
+  fromId?: number | string;
+  fromUsername?: string;
+  isBot?: boolean;
+  chatType?: TelegramChatType;
+  chatUsername?: string;
+  messageId?: number;
+  entities?: TelegramMessageEntity[];
+}
+
+interface PendingWaiter {
+  resolve: (updates: TelegramUpdate[]) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+/**
+ * Network-free Telegram connector for tests. Feed inbound updates with
+ * {@link FakeTelegramClient.pushUpdate}; inspect outbound calls via `sent` and
+ * `chatActions`. getUpdates long-polls: it resolves immediately when updates
+ * are queued, otherwise it parks until the next pushUpdate or an abort.
+ */
+export class FakeTelegramClient implements TelegramClient {
+  readonly sent: FakeTelegramSentMessage[] = [];
+  readonly chatActions: FakeTelegramChatAction[] = [];
+  me: TelegramUser = {
+    id: 1000,
+    is_bot: true,
+    username: 'clawbot',
+    first_name: 'Claw',
+  };
+
+  private readonly pending: TelegramUpdate[] = [];
+  private readonly errorQueue: unknown[] = [];
+  private waiter?: PendingWaiter;
+  private updateSeq = 1;
+  private messageSeq = 1;
+
+  async getMe(): Promise<TelegramUser> {
+    return this.me;
+  }
+
+  /** Queue an error to be thrown by the next getUpdates call. */
+  failNextGetUpdates(error: unknown): void {
+    this.errorQueue.push(error);
+  }
+
+  getUpdates({ signal }: GetUpdatesParams): Promise<TelegramUpdate[]> {
+    if (this.errorQueue.length > 0) {
+      return Promise.reject(this.errorQueue.shift());
+    }
+    if (signal?.aborted) {
+      return Promise.resolve([]);
+    }
+    if (this.pending.length > 0) {
+      return Promise.resolve(this.drain());
+    }
+    return new Promise<TelegramUpdate[]>((resolve) => {
+      const onAbort = () => {
+        this.waiter = undefined;
+        resolve([]);
+      };
+      this.waiter = { resolve, signal, onAbort };
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  pushUpdate(options: FakePushMessageOptions): TelegramUpdate {
+    const chatType = options.chatType ?? 'private';
+    const chatId =
+      typeof options.chatId === 'number'
+        ? options.chatId
+        : Number(options.chatId);
+    const fromId =
+      options.fromId !== undefined ? Number(options.fromId) : chatId;
+    const message: TelegramMessage = {
+      message_id: options.messageId ?? this.messageSeq++,
+      from: {
+        id: fromId,
+        is_bot: options.isBot ?? false,
+        username: options.fromUsername,
+        first_name: options.fromUsername ?? 'User',
+      },
+      chat: {
+        id: chatId,
+        type: chatType,
+        username: options.chatUsername,
+      },
+      text: options.text,
+      entities: options.entities,
+    };
+    const update: TelegramUpdate = {
+      update_id: this.updateSeq++,
+      message,
+    };
+    if (this.waiter) {
+      const waiter = this.waiter;
+      this.waiter = undefined;
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort);
+      }
+      waiter.resolve([update]);
+    } else {
+      this.pending.push(update);
+    }
+    return update;
+  }
+
+  async sendMessage({
+    chatId,
+    text,
+    replyToMessageId,
+  }: SendMessageParams): Promise<TelegramMessage> {
+    this.sent.push({ chatId, text, replyToMessageId });
+    return {
+      message_id: this.messageSeq++,
+      chat: { id: Number(chatId), type: 'private' },
+      text,
+    };
+  }
+
+  async sendChatAction({
+    chatId,
+    action,
+  }: SendChatActionParams): Promise<void> {
+    this.chatActions.push({ chatId, action });
+  }
+
+  private drain(): TelegramUpdate[] {
+    const updates = [...this.pending];
+    this.pending.length = 0;
+    return updates;
+  }
+}
+
+export function mockTelegram(): FakeTelegramClient {
+  return new FakeTelegramClient();
+}

--- a/packages/telegram/tsconfig.json
+++ b/packages/telegram/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020", "DOM"],
+    "composite": true,
+    "rootDir": "src",
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/telegram/tsup.config.ts
+++ b/packages/telegram/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/testing.ts'],
+  format: ['esm'],
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  outDir: 'dist',
+});

--- a/packages/telegram/vitest.config.ts
+++ b/packages/telegram/vitest.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@prompttrail/core/runtime_server',
+        replacement: new URL('../core/src/runtime_server.ts', import.meta.url)
+          .pathname,
+      },
+      {
+        find: '@prompttrail/core/runtime_dispatch',
+        replacement: new URL('../core/src/runtime_dispatch.ts', import.meta.url)
+          .pathname,
+      },
+      {
+        find: '@prompttrail/core',
+        replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
+      },
+    ],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/__tests__/**'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@prompttrail/store-sqlite':
         specifier: workspace:*
         version: link:../packages/store-sqlite
+      '@prompttrail/telegram':
+        specifier: workspace:*
+        version: link:../packages/telegram
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -459,6 +462,28 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/node':
+        specifier: ^20.17.19
+        version: 20.17.32
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.17.32)(lightningcss@1.29.2))
+      tsup:
+        specifier: ^8.3.6
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.17.32)(lightningcss@1.29.2)
+
+  packages/telegram:
+    dependencies:
+      '@prompttrail/core':
+        specifier: link:../core
+        version: link:../core
+    devDependencies:
       '@types/node':
         specifier: ^20.17.19
         version: 20.17.32
@@ -2985,6 +3010,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
New platform package mirroring @prompttrail/discord, zero heavy deps (plain fetch long-polling). claw wires it in parallel to Discord behind TELEGRAM_TOKEN — same skills/dispatch agent, either or both channels.

The roadmap's actual question — 'validates that runtime_bindings is not Discord-shaped' — held up with **no core changes**: generic TriggerEvent/DeliveryTarget absorbed Telegram's fields; the websocket-push vs HTTPS-long-poll structural difference fit the start(ctx)/stop() contract unchanged; outbox dedup, presence, and conversation locking came free from the three generic driver arrays. Full honest assessment in the commit/agent notes.

telegram 21 tests (incl. real RuntimeServer integration via FakeTelegramClient, chunking, mention-stripping, poll-abort, backoff), claw 41 (+5 token-resolution), discord/cron/core unchanged green. build/typecheck/lint/prettier clean.