### PR TITLE
feat: B3 — acceptance suite (trusted-root forward tests)

### DIFF
--- a/claw/acceptance/builtin-corpus.ts
+++ b/claw/acceptance/builtin-corpus.ts
@@ -1,0 +1,207 @@
+import {
+  type AcceptanceCase,
+  type ReplayTrace,
+  type Session,
+  Source,
+} from '@prompttrail/core';
+import {
+  createAuthorSkill,
+  createClawSkillAgent,
+  createStatusSkill,
+  createSupervisorSkill,
+  findClawRoot,
+  MATCHED_SKILL_VAR,
+  registerBuiltinSkills,
+  SkillRegistry,
+  templateSynthesizer,
+  type Skill,
+  type SkillLoaderContext,
+} from '../src/skills/index.js';
+
+/**
+ * B3 — claw's builtin acceptance corpus (design-docs/replay-and-self-deploy.md
+ * §4, §6, §8 B3).
+ *
+ * TRUST BOUNDARY (design §6). This corpus and the agent it targets live under
+ * `claw/acceptance/` — REPO SOURCE, checked into git. The self-authoring loader
+ * and gate only ever write to env-configured `.data` paths (`CLAW_SKILLS_DIR`,
+ * its `staging/` subdir, and the `*.db` files — see `claw/src/index.ts` and
+ * `skills/loader.ts`/`gate.ts`); they never touch `claw/acceptance/` or
+ * `claw/src/`. So a self-authored / self-modified build under test CANNOT edit
+ * this corpus or weaken the checks it asserts — the acceptance suite is
+ * trusted-root owned, and green only ever RUNS it against itself.
+ *
+ * Every case runs on the deterministic ECHO reply mode with callback/transform
+ * skills (status, supervisor, author), so no case reaches the network: the
+ * builtin behaviors make no model calls, and the acceptance containment seals
+ * tools and captures deliveries regardless.
+ */
+
+/** A privileged channel the supervisor/author skills are narrowed to. */
+const PRIVILEGED_CHANNEL = 'ops';
+/** An ordinary channel with no elevated capability. */
+const PUBLIC_CHANNEL = 'general';
+
+/** Deterministic status facts (pinned clock → stable uptime). */
+const STATUS_INFO = {
+  version: '9.9.9',
+  replyMode: 'echo',
+  startedAt: 0,
+  now: () => 42_000,
+};
+
+/**
+ * Build the acceptance TARGET: claw's static registry-dispatch agent wired with
+ * the builtin skills exactly as production does, minus any network reply mode.
+ * A fresh in-memory registry keeps every run hermetic.
+ */
+export function buildAcceptanceTarget() {
+  const registry = new SkillRegistry(':memory:');
+  const loaderContext: SkillLoaderContext = {
+    registry,
+    skills: new Map<string, Skill>(),
+    // Never written during acceptance (gate/loader are not invoked), but the
+    // path is required by the type; it points at the env .data surface, which is
+    // outside this corpus (the trust boundary above).
+    skillsDir: '.data/skills',
+    replySource: Source.callback(async () => '(echo mode: skill reply)'),
+    gateOptions: {
+      clawRoot: findClawRoot(),
+      stagingRoot: '.data/skills/staging',
+    },
+  };
+  const authorSkill = createAuthorSkill({
+    loaderContext,
+    synthesizer: templateSynthesizer,
+    authoringChannels: [PRIVILEGED_CHANNEL],
+    authors: [],
+  });
+  const supervisorSkill = createSupervisorSkill({
+    loaderContext,
+    supervisorChannels: [PRIVILEGED_CHANNEL],
+    authors: [],
+  });
+  const statusSkill = createStatusSkill(STATUS_INFO);
+
+  const skills = registerBuiltinSkills(registry, [
+    statusSkill,
+    supervisorSkill,
+    authorSkill,
+  ]);
+  loaderContext.skills = skills;
+
+  return createClawSkillAgent({
+    registry,
+    skills,
+    defaultReply: (agent) =>
+      agent.assistant(
+        'reply',
+        (session: Session) => `ack: ${session.getLastMessage()?.content ?? ''}`,
+      ),
+  });
+}
+
+/** Read the dispatch-written matched skill id off the final session. */
+function matchedSkill(session: Session): string {
+  const value = (session.getVarsObject() as Record<string, unknown>)[
+    MATCHED_SKILL_VAR
+  ];
+  return typeof value === 'string' ? value : '';
+}
+
+/** The last assistant reply text. */
+function reply(session: Session): string {
+  return session.getLastMessage()?.content ?? '';
+}
+
+/** The `route` conditional's branch decision (routing dimension). */
+function routeBranch(trace: ReplayTrace): string | undefined {
+  return trace.routing.find((r) => r.at.endsWith('/route'))?.branch;
+}
+
+/**
+ * Corpus v1 — the forward assertions on claw's builtin dispatch behavior. Each
+ * asserts on the DETERMINISTIC dimensions (routing branch + which skill matched)
+ * plus a text regex; no case depends on live model output.
+ */
+export const builtinCorpus: AcceptanceCase[] = [
+  {
+    name: 'status skill answers !status',
+    inbox: ['!status'],
+    assert: (trace, session) => {
+      // Routing: dispatch → status skill (then branch).
+      expect(routeBranch(trace)).toBe('then');
+      expect(matchedSkill(session)).toBe('status');
+      // Text: version | reply-mode | uptime shape.
+      expect(reply(session)).toMatch(
+        /^claw v\d.*\|\s*reply-mode:\s*\S+\s*\|\s*uptime:\s*\d+s$/,
+      );
+    },
+  },
+  {
+    name: 'unauthorized channel does NOT trigger authoring',
+    inbox: [
+      { content: '!skill add a greeter', attrs: { channel: PUBLIC_CHANNEL } },
+    ],
+    assert: (trace, session) => {
+      // The author skill is channel-narrowed to PRIVILEGED_CHANNEL, so on a
+      // public channel it never matches — dispatch takes the else (default)
+      // branch and NOTHING authored.
+      expect(matchedSkill(session)).toBe('');
+      expect(routeBranch(trace)).toBe('else');
+      expect(reply(session)).toBe('ack: !skill add a greeter');
+    },
+  },
+  {
+    name: 'supervisor !skills is rejected on a public channel',
+    inbox: [{ content: '!skills', attrs: { channel: PUBLIC_CHANNEL } }],
+    assert: (trace, session) => {
+      // Supervisor is channel-narrowed; a public !skills falls through to echo.
+      expect(matchedSkill(session)).toBe('');
+      expect(routeBranch(trace)).toBe('else');
+      expect(reply(session)).toBe('ack: !skills');
+    },
+  },
+  {
+    name: 'supervisor !skills runs on the privileged channel',
+    inbox: [{ content: '!skills', attrs: { channel: PRIVILEGED_CHANNEL } }],
+    assert: (trace, session) => {
+      expect(routeBranch(trace)).toBe('then');
+      expect(matchedSkill(session)).toBe('supervisor');
+      // The skills listing renders (privileged capability exercised).
+      expect(reply(session)).toMatch(/Skills \(\d+\)/);
+    },
+  },
+  {
+    name: 'default echo reply for an unmatched message',
+    inbox: ['just saying hello'],
+    assert: (trace, session) => {
+      expect(matchedSkill(session)).toBe('');
+      expect(routeBranch(trace)).toBe('else');
+      expect(reply(session)).toBe('ack: just saying hello');
+    },
+  },
+];
+
+/**
+ * Minimal assertion helper so the corpus stays dependency-free of the test
+ * runner: each case throws on a mismatch, which {@link runAcceptance} captures.
+ */
+function expect(actual: unknown) {
+  return {
+    toBe(expected: unknown) {
+      if (actual !== expected) {
+        throw new Error(
+          `expected ${JSON.stringify(actual)} to be ${JSON.stringify(expected)}`,
+        );
+      }
+    },
+    toMatch(re: RegExp) {
+      if (typeof actual !== 'string' || !re.test(actual)) {
+        throw new Error(
+          `expected ${JSON.stringify(actual)} to match ${re.toString()}`,
+        );
+      }
+    },
+  };
+}

--- a/claw/package.json
+++ b/claw/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
+    "acceptance": "tsx src/acceptance-runner.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest --run --watch=false",
     "test:watch": "vitest watch"

--- a/claw/src/acceptance-runner.test.ts
+++ b/claw/src/acceptance-runner.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatAcceptanceReport,
+  runClawAcceptance,
+} from './acceptance-runner.js';
+
+/**
+ * B3 — the trusted-runner acceptance corpus, invoked in-process (not as a
+ * subprocess). The runner builds claw's dispatch agent and runs the trusted-root
+ * corpus against it through the core acceptance containment.
+ */
+describe('claw builtin acceptance corpus', () => {
+  it('passes every case through the trusted runner', async () => {
+    const report = await runClawAcceptance();
+    // Surface the specific failing case(s) if the corpus regresses.
+    if (!report.ok) {
+      throw new Error(
+        `acceptance regressed:\n${formatAcceptanceReport(report)}`,
+      );
+    }
+    expect(report.ok).toBe(true);
+    expect(report.cases).toHaveLength(5);
+    for (const result of report.cases) {
+      expect(result.ok).toBe(true);
+      expect(typeof result.durationMs).toBe('number');
+    }
+  });
+});

--- a/claw/src/acceptance-runner.ts
+++ b/claw/src/acceptance-runner.ts
@@ -1,0 +1,51 @@
+import { fileURLToPath } from 'node:url';
+import { type AcceptanceReport, runAcceptance } from '@prompttrail/core';
+import {
+  buildAcceptanceTarget,
+  builtinCorpus,
+} from '../acceptance/builtin-corpus.js';
+
+/**
+ * B3 acceptance runner (design-docs/replay-and-self-deploy.md §4, §6, §8 B3).
+ *
+ * The TRUSTED runner: it constructs the target agent and executes the
+ * trusted-root corpus against it through the core acceptance containment (sealed
+ * side effects, captured deliveries, live model fall-through only). It is
+ * deliberately thin — the corpus and its target live in `claw/acceptance/`, repo
+ * source outside any self-authoring write path (see the corpus header for the
+ * trust-boundary argument) — so a mutable build under test can never edit what
+ * grades it.
+ *
+ * Exposed as {@link runClawAcceptance} for the vitest suite (invoked directly,
+ * not as a subprocess) and runnable as `pnpm --filter @prompttrail/claw
+ * acceptance`.
+ */
+export async function runClawAcceptance(): Promise<AcceptanceReport> {
+  const target = buildAcceptanceTarget();
+  return runAcceptance(target, builtinCorpus);
+}
+
+/** Print a human-readable summary of an acceptance report. */
+export function formatAcceptanceReport(report: AcceptanceReport): string {
+  const lines = report.cases.map((c) => {
+    const mark = c.ok ? 'PASS' : 'FAIL';
+    const detail = c.ok ? '' : ` — ${c.error ?? 'unknown error'}`;
+    return `  [${mark}] ${c.name} (${c.durationMs}ms)${detail}`;
+  });
+  const failed = report.cases.filter((c) => !c.ok).length;
+  const header = report.ok
+    ? `Acceptance: all ${report.cases.length} cases passed.`
+    : `Acceptance: ${failed}/${report.cases.length} cases FAILED.`;
+  return [header, ...lines].join('\n');
+}
+
+async function main(): Promise<void> {
+  const report = await runClawAcceptance();
+  console.log(formatAcceptanceReport(report));
+  process.exitCode = report.ok ? 0 : 1;
+}
+
+// Run as a script only when invoked directly (not when imported by the test).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/claw/tsconfig.json
+++ b/claw/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
@@ -13,5 +13,5 @@
     "sourceMap": true,
     "noEmit": false
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "acceptance/**/*.ts"]
 }

--- a/packages/core/src/__tests__/unit/acceptance.test.ts
+++ b/packages/core/src/__tests__/unit/acceptance.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { runAcceptance } from '../../acceptance';
+import type { AcceptanceCase } from '../../acceptance';
+import type { ReplayTrace } from '../../replay';
+import type { Session } from '../../session';
+import { Source } from '../../source';
+import { Agent } from '../../templates';
+import { Tool } from '../../tool';
+
+/** An echo agent with no model call — the deterministic acceptance target. */
+function echoAgent() {
+  return Agent.create('echo')
+    .inbox('in')
+    .assistant(
+      'reply',
+      (session) => `ack: ${session.getLastMessage()?.content}`,
+    );
+}
+
+function lastAssistant(session: Session): string | undefined {
+  return [...session.messages].reverse().find((m) => m.type === 'assistant')
+    ?.content;
+}
+
+describe('B3 acceptance mode — live model, sealed tools', () => {
+  it('falls a model miss through to the REAL provider while a tool miss stays sealed', async () => {
+    let sideEffectCount = 0;
+    const countingTool = Tool.create({
+      name: 'bump',
+      description: 'Increments a counter as a side effect.',
+      inputSchema: z.object({ n: z.number() }),
+      effect: { idempotencyKey: 'bump:1' },
+      execute: (input: { n: number }) => {
+        sideEffectCount += 1;
+        return `bumped:${input.n}`;
+      },
+    });
+    // The mock LLM source stands in for the REAL provider: on a cassette miss
+    // under `miss: 'live'`, the funnel runs it (not a sentinel).
+    const liveModel = Source.llm({ temperature: 0 })
+      .mock()
+      .mockResponse({
+        content: 'live-answer',
+        toolCalls: [{ id: 'c1', name: 'bump', arguments: { n: 7 } }],
+      });
+    const agent = Agent.create('acc')
+      .inbox('in')
+      .tool('bump', countingTool)
+      .assistant('ask', liveModel)
+      .tools('run');
+
+    let captured: { trace: ReplayTrace; session: Session } | undefined;
+    const cases: AcceptanceCase[] = [
+      {
+        name: 'live-model-sealed-tool',
+        inbox: ['hello'],
+        // No modelStubs and no cassette → the model call goes live, the tool
+        // call is sealed to a sentinel.
+        assert: (trace, session) => {
+          captured = { trace, session };
+        },
+      },
+    ];
+
+    const report = await runAcceptance(agent, cases);
+    expect(report.ok).toBe(true);
+
+    const { trace, session } = captured!;
+    // The tool NEVER executed — side effects stay sealed even in acceptance.
+    expect(sideEffectCount).toBe(0);
+    // The model call fell through to the live mock and is flagged `live`.
+    const modelMiss = trace.misses.find((m) => m.kind === 'model');
+    expect(modelMiss).toMatchObject({ kind: 'model', live: true });
+    // The tool miss is sealed — recorded WITHOUT a `live` marker.
+    const toolMiss = trace.misses.find((m) => m.kind === 'tool');
+    expect(toolMiss).toBeDefined();
+    expect(toolMiss?.live).toBeUndefined();
+    // The live model output actually reached the session.
+    expect(
+      session.messages.some((m) => m.content.includes('live-answer')),
+    ).toBe(true);
+    // The sealed tool result is the sentinel, not a real `bumped:7`.
+    const toolResult = session.messages.find((m) => m.type === 'tool_result');
+    expect(toolResult?.content).toContain('[replay-miss]');
+  });
+});
+
+describe('B3 runAcceptance report shape', () => {
+  it('reports ok:false with the failing case captured, both durations recorded', async () => {
+    const cases: AcceptanceCase[] = [
+      {
+        name: 'passes',
+        inbox: ['ping'],
+        assert: (_trace, session) => {
+          expect(lastAssistant(session)).toBe('ack: ping');
+        },
+      },
+      {
+        name: 'fails',
+        inbox: ['ping'],
+        assert: () => {
+          throw new Error('intentional acceptance failure');
+        },
+      },
+    ];
+
+    const report = await runAcceptance(echoAgent(), cases);
+    expect(report.ok).toBe(false);
+    expect(report.cases).toHaveLength(2);
+
+    const [pass, fail] = report.cases;
+    expect(pass).toMatchObject({ name: 'passes', ok: true });
+    expect(pass.error).toBeUndefined();
+    expect(fail).toMatchObject({ name: 'fails', ok: false });
+    expect(fail.error).toContain('intentional acceptance failure');
+    // Both cases ran (no abort on the first failure) and are timed.
+    for (const result of report.cases) {
+      expect(typeof result.durationMs).toBe('number');
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('does not abort the suite when an earlier case fails', async () => {
+    const cases: AcceptanceCase[] = [
+      {
+        name: 'first-fails',
+        inbox: ['x'],
+        assert: () => {
+          throw new Error('boom');
+        },
+      },
+      {
+        name: 'second-still-runs',
+        inbox: ['ping'],
+        assert: (_trace, session) => {
+          expect(lastAssistant(session)).toBe('ack: ping');
+        },
+      },
+    ];
+    const report = await runAcceptance(echoAgent(), cases);
+    expect(report.cases.map((c) => c.ok)).toEqual([false, true]);
+  });
+});
+
+describe('B3 modelStubs sugar', () => {
+  it('builds a positional cassette so the model call resolves from a stub (no live)', async () => {
+    const agent = Agent.create('stubbed')
+      .inbox('in')
+      .assistant('reply', Source.llm({ temperature: 0 }));
+
+    let captured: ReplayTrace | undefined;
+    const cases: AcceptanceCase[] = [
+      {
+        name: 'stub-resolves',
+        inbox: ['question'],
+        modelStubs: ['stubbed-response'],
+        assert: (trace, session) => {
+          captured = trace;
+          expect(
+            session.messages.some((m) =>
+              m.content.includes('stubbed-response'),
+            ),
+          ).toBe(true);
+        },
+      },
+    ];
+
+    const report = await runAcceptance(agent, cases);
+    expect(report.ok).toBe(true);
+    // The stub was consumed positionally — no live fall-through.
+    expect(captured!.misses).toEqual([]);
+    expect(captured!.modelCalls).toHaveLength(1);
+    expect(captured!.modelCalls[0].hit).toBe('positional');
+  });
+});

--- a/packages/core/src/__tests__/unit/public_api.test.ts
+++ b/packages/core/src/__tests__/unit/public_api.test.ts
@@ -89,6 +89,7 @@ describe('public API surface', () => {
       'parseDuration',
       'replayRun',
       'replaySelfCheck',
+      'runAcceptance',
       'stableStringify',
       'validateAgentGraph',
     ]);

--- a/packages/core/src/__tests__/unit/replay.test.ts
+++ b/packages/core/src/__tests__/unit/replay.test.ts
@@ -260,14 +260,16 @@ describe('B1 miss policy', () => {
     ).rejects.toBeInstanceOf(ReplayMissError);
   });
 
-  it("rejects the 'live' miss policy (not supported until B3+)", async () => {
+  it("rejects the 'live' miss policy outside the acceptance containment", async () => {
     const { run } = await recordRun(recordingAgent(), {
       runId: 'miss-2',
       agentName: 'rec',
       input: 'hello',
     });
+    // Without `acceptance: true`, a live provider fall-through is a foot-gun and
+    // is rejected (design §4 — use runAcceptance / pass acceptance: true).
     await expect(replayRun(run, { miss: 'live' })).rejects.toThrow(
-      /'live'.*not supported/,
+      /'live'.*requires the acceptance containment/,
     );
   });
 

--- a/packages/core/src/acceptance.ts
+++ b/packages/core/src/acceptance.ts
@@ -1,0 +1,198 @@
+import { createCheckpointOnceMemoStore } from './checkpoint_continuation';
+import type { Inbound, ModelCallRecord, StoredRun } from './durable';
+import type { Cassette, ReplayTrace } from './replay';
+import { replayRun } from './replay';
+import type { Session, Vars } from './session';
+import { createSession } from './session';
+import type { Agent } from './templates';
+
+/**
+ * B3 — the acceptance suite (design-docs replay-and-self-deploy.md §4, §8).
+ *
+ * Acceptance validates NEW behavior FORWARD: a corpus of synthetic fake
+ * requests, each asserting what the target agent should now do (routes to the
+ * right skill, calls the right tool with the right args, replies within budget,
+ * terminates). Past requests cannot exercise behavior that postdates them, so
+ * this is the complement to the replay-diff over the historical corpus.
+ *
+ * It runs on the SAME containment as {@link replayRun} — a fresh throwaway run,
+ * side effects sealed, deliveries captured into `trace.wouldDeliver` and never
+ * sent — with one delta: `miss: 'live'` under `acceptance: true`, so a MODEL
+ * call the case did not stub falls through to the real provider (new behavior =
+ * genuinely new LLM output). TOOL calls stay SEALED even here (a tool miss is a
+ * stub/sentinel, never a live execution — see `replay.ts`), so assertions on the
+ * deterministic dimensions (routing / tool / structured) hold even when the text
+ * dimension is live.
+ *
+ * TRUST BOUNDARY (design §6). This harness — like the corpus that feeds it — is
+ * TRUSTED-ROOT: it must live outside what a self-authored / self-modified build
+ * under test can edit, so a broken green cannot ship with a weakened self-check.
+ * A green build RUNS this against itself as a target; it can never rewrite it.
+ */
+
+/** One synthetic fake request in a case's inbox (a `string` = a user message). */
+export type AcceptanceInboxItem =
+  | string
+  | {
+      kind?: Inbound['kind'];
+      content: string;
+      /** Routing attrs (e.g. `channel`) the dispatch path reads. */
+      attrs?: Record<string, unknown>;
+    };
+
+export interface AcceptanceCase {
+  /** Stable, human-readable case id (surfaced in the report). */
+  name: string;
+  /** The synthetic fake requests fed to the target agent, in order. */
+  inbox: AcceptanceInboxItem[];
+  /** Services made available to the run (e.g. a delivery target). */
+  services?: Record<string, unknown>;
+  /**
+   * An explicit cassette to stub model AND tool leaves for this case. Consumed
+   * positionally. Tool stubs are the ONLY way to give a tool call a specific
+   * result — tools never go live. Mutually rich with {@link modelStubs}; if both
+   * are set, `cassette` wins.
+   */
+  cassette?: Cassette;
+  /**
+   * Sugar for the common case: positional model responses (assistant text), in
+   * order. Built into a model-only cassette. A model call past the last stub
+   * falls through to the real provider (`miss: 'live'`). Ignored if
+   * {@link cassette} is set.
+   */
+  modelStubs?: string[];
+  /**
+   * The assertion. Throwing (e.g. a failed `expect`) fails the case; the thrown
+   * error is captured into the report. May be async.
+   */
+  assert: (trace: ReplayTrace, session: Session) => void | Promise<void>;
+}
+
+export interface AcceptanceCaseResult {
+  name: string;
+  ok: boolean;
+  durationMs: number;
+  /** The failure message when `ok` is false (assertion throw or run error). */
+  error?: string;
+}
+
+export interface AcceptanceReport {
+  /** True iff EVERY case passed. */
+  ok: boolean;
+  cases: AcceptanceCaseResult[];
+}
+
+export interface RunAcceptanceOptions {
+  /**
+   * Keying tried per model/tool call (design §2). Defaults to `['positional']`
+   * — stubs are positional and forward cases assume no historical divergence.
+   */
+  keying?: readonly ('request-hash' | 'node-path' | 'positional')[];
+  /** Pinned clock; defaults to the replay's fixed epoch. */
+  now?: () => number;
+  /** Pinned event scope / conversation id; defaults to `acceptance:<name>`. */
+  eventScopeId?: (name: string) => string;
+}
+
+/** Build a model-only cassette from positional assistant-text stubs. */
+function modelStubsToCassette(stubs: readonly string[]): Cassette {
+  const model: ModelCallRecord[] = stubs.map((text, index) => ({
+    seq: index,
+    nodePath: '',
+    callIndex: index,
+    provider: 'assistant',
+    // Positional keying only reads insertion order, so a placeholder digest is
+    // fine; a request-hash keyed acceptance would supply a real `cassette`.
+    requestDigest: '',
+    response: { content: text },
+    at: 0,
+  }));
+  return { model, tools: [], nodes: [] };
+}
+
+const EMPTY_CASSETTE: Cassette = { model: [], tools: [], nodes: [] };
+
+/** Normalize an inbox item into a stored {@link Inbound}. */
+function toInbound(item: AcceptanceInboxItem, offset: number): Inbound {
+  if (typeof item === 'string') {
+    return { offset, kind: 'user', content: item };
+  }
+  return {
+    offset,
+    kind: item.kind ?? 'user',
+    content: item.content,
+    attrs: item.attrs,
+  };
+}
+
+/**
+ * Build the synthetic {@link StoredRun} for one case. It carries no recording
+ * (the cassette is supplied explicitly, so `buildCassette` is never reached) and
+ * an empty initial session — the fake requests drive everything from the inbox.
+ */
+function syntheticRun(agent: Agent, testCase: AcceptanceCase): StoredRun<Vars> {
+  return {
+    agent,
+    agentName: agent.name ?? 'acceptance',
+    initial: createSession(),
+    status: 'open',
+    once: createCheckpointOnceMemoStore(),
+    outbox: [],
+    inbox: testCase.inbox.map((item, index) => toInbound(item, index)),
+    services: testCase.services,
+  };
+}
+
+/**
+ * Run an acceptance corpus against a target agent, sequentially, collecting
+ * every case's outcome WITHOUT aborting the suite on a failure (design §4/§8).
+ * Each case runs through the {@link replayRun} acceptance containment.
+ */
+export async function runAcceptance(
+  agent: Agent,
+  cases: readonly AcceptanceCase[],
+  opts: RunAcceptanceOptions = {},
+): Promise<AcceptanceReport> {
+  const keying = opts.keying ?? (['positional'] as const);
+  const eventScopeId =
+    opts.eventScopeId ?? ((name: string) => `acceptance:${name}`);
+  const results: AcceptanceCaseResult[] = [];
+
+  for (const testCase of cases) {
+    const start = Date.now();
+    const cassette =
+      testCase.cassette ??
+      (testCase.modelStubs
+        ? modelStubsToCassette(testCase.modelStubs)
+        : EMPTY_CASSETTE);
+    try {
+      const { trace, session } = await replayRun(
+        syntheticRun(agent, testCase),
+        {
+          agent,
+          cassette,
+          keying,
+          miss: 'live',
+          acceptance: true,
+          now: opts.now,
+          eventScopeId: eventScopeId(testCase.name),
+        },
+      );
+      await testCase.assert(trace, session);
+      results.push({
+        name: testCase.name,
+        ok: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (error) {
+      results.push({
+        name: testCase.name,
+        ok: false,
+        durationMs: Date.now() - start,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { ok: results.every((result) => result.ok), cases: results };
+}

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -66,13 +66,25 @@ export interface ToolExecutionContext {
  * tool. A miss (cassette exhausted / kind mismatch) throws under B1's
  * `miss: 'error'` policy — the implementation lives in `replay.ts`.
  */
+/**
+ * Sentinel a {@link ReplayLeafSource.model} returns to instruct the model
+ * funnel to fall through to the REAL provider (design-docs
+ * replay-and-self-deploy.md §4, B3 acceptance). Returned only under the
+ * `miss: 'live'` policy (acceptance mode) when the cassette cannot serve the
+ * call — the funnel then runs the genuine model call instead of a sentinel.
+ * Tool calls never receive this: side effects stay sealed in acceptance, so a
+ * tool miss always resolves to a stub/sentinel, never a live execution.
+ */
+export const REPLAY_GO_LIVE = Symbol('prompttrail.replay.go-live');
+
 export interface ReplayLeafSource {
   /**
    * Serve a recorded model/provider response for a model node. `requestSession`
    * + `requestMeta` let the replay source digest the candidate's live request
    * the SAME way the recorder did (`computeModelRequestDigest`), so
    * `request-hash` keying is well-defined (B2). B1's positional source ignores
-   * them.
+   * them. Returns {@link REPLAY_GO_LIVE} to instruct the funnel to run the real
+   * provider (acceptance `miss: 'live'` fall-through, B3).
    */
   model(input: {
     nodePath: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,14 @@ export type {
   ReplaySelfCheck,
   ReplayTrace,
 } from './replay';
+export { runAcceptance } from './acceptance';
+export type {
+  AcceptanceCase,
+  AcceptanceCaseResult,
+  AcceptanceInboxItem,
+  AcceptanceReport,
+  RunAcceptanceOptions,
+} from './acceptance';
 export { ChangeScopeSchema, buildGoldenOutcome, diffReplay } from './diff';
 export type {
   ChangeScope,

--- a/packages/core/src/replay.ts
+++ b/packages/core/src/replay.ts
@@ -1,4 +1,8 @@
-import type { CallToolResult, ReplayLeafSource } from './capabilities';
+import {
+  REPLAY_GO_LIVE,
+  type CallToolResult,
+  type ReplayLeafSource,
+} from './capabilities';
 import type {
   AssistantDeliveryOutboxInput,
   ModelCallRecord,
@@ -133,10 +137,18 @@ export interface ReplayTrace {
   /** Deliveries captured but never sent (no drivers on the throwaway path). */
   wouldDeliver: AssistantDeliveryOutboxInput[];
   /**
-   * Divergence points recorded under `miss: 'flag'` — a leaf no keying level
-   * could serve. Always empty under `miss: 'error'` (a miss throws instead).
+   * Divergence points recorded under `miss: 'flag'`/`'live'` — a leaf no keying
+   * level could serve. Always empty under `miss: 'error'` (a miss throws
+   * instead). `live: true` marks a model call that fell through to the REAL
+   * provider under the acceptance `miss: 'live'` policy (design §4), so an
+   * assertion can see exactly what went live; a sealed sentinel miss omits it.
    */
-  misses: { at: string; kind: 'model' | 'tool'; position: number }[];
+  misses: {
+    at: string;
+    kind: 'model' | 'tool';
+    position: number;
+    live?: boolean;
+  }[];
 }
 
 export interface ReplayOptions {
@@ -155,9 +167,22 @@ export interface ReplayOptions {
   /**
    * Miss policy (design §2). `error` (default) throws {@link ReplayMissError};
    * `flag` records the divergence and continues with a sentinel. `live` (real
-   * provider fall-through) is rejected until B3+.
+   * MODEL-call fall-through — design §4 acceptance) is permitted ONLY together
+   * with `acceptance: true`; otherwise it is rejected, since a live provider
+   * call outside the acceptance containment is a foot-gun.
    */
   miss?: 'flag' | 'error' | 'live';
+  /**
+   * Authorize the acceptance containment (design §4, B3): allow `miss: 'live'`
+   * so a cassette miss on a MODEL call falls through to the real provider (new
+   * behavior = genuinely new LLM output). Tool calls stay SEALED even here — a
+   * tool miss resolves to a stub/sentinel, never a live execution — and
+   * deliveries stay captured in `wouldDeliver`. This is the ONE delta between a
+   * plain replay and an acceptance run, so it is a flag on `replayRun` rather
+   * than a duplicate `acceptanceRun` entry point; {@link runAcceptance} in
+   * `acceptance.ts` is the harness built on top of it.
+   */
+  acceptance?: boolean;
   /** Pinned clock for record timestamps; defaults to a fixed epoch. */
   now?: () => number;
   /** Pinned event scope / conversation id; defaults to a stable constant. */
@@ -297,7 +322,7 @@ class KeyedReplaySource implements ReplayLeafSource {
   constructor(
     private readonly cassette: Cassette,
     private readonly keying: readonly KeyingLevel[],
-    private readonly miss: 'flag' | 'error',
+    private readonly miss: 'flag' | 'error' | 'live',
   ) {
     this.modelConsumed = new Array(cassette.model.length).fill(false);
     this.toolConsumed = new Array(cassette.tools.length).fill(false);
@@ -333,6 +358,19 @@ class KeyedReplaySource implements ReplayLeafSource {
         actual: 'no keying level matched (cassette exhausted or divergent)',
       });
     }
+    if (this.miss === 'live') {
+      // Acceptance (design §4): the new behavior is genuinely new model output,
+      // so fall through to the REAL provider. Record the fall-through with a
+      // `live` marker; the funnel runs the actual call and its response is
+      // captured by the recorder, not by this trace's `modelCalls`.
+      this.misses.push({
+        at: input.nodePath,
+        kind: 'model',
+        position,
+        live: true,
+      });
+      return REPLAY_GO_LIVE;
+    }
     this.misses.push({ at: input.nodePath, kind: 'model', position });
     return cloneValue(MODEL_MISS_SENTINEL);
   }
@@ -365,6 +403,11 @@ class KeyedReplaySource implements ReplayLeafSource {
         actual: 'no keying level matched (cassette exhausted or divergent)',
       });
     }
+    // ASYMMETRY (design §4): under acceptance `miss: 'live'` only MODEL calls go
+    // live; a tool miss stays SEALED — side effects must never run in a dry-run
+    // acceptance. So `live` and `flag` both resolve a tool miss to the sentinel
+    // (no `live` marker), and a case that needs a specific tool result supplies
+    // it as a stub via its cassette.
     this.misses.push({ at: input.nodePath, kind: 'tool', position });
     return cloneValue(TOOL_MISS_SENTINEL);
   }
@@ -425,11 +468,12 @@ export async function replayRun<TVars extends Vars = Vars>(
   run: StoredRun<TVars>,
   opts: ReplayOptions = {},
 ): Promise<ReplayResult<TVars>> {
-  if (opts.miss === 'live') {
+  if (opts.miss === 'live' && !opts.acceptance) {
     throw new Error(
-      "Replay miss policy 'live' (real provider fall-through) is not supported " +
-        "yet — see design-docs replay-and-self-deploy.md §2/B3+. Use 'flag' or " +
-        "'error'.",
+      "Replay miss policy 'live' (real provider fall-through) requires the " +
+        'acceptance containment — pass `acceptance: true` (design-docs ' +
+        'replay-and-self-deploy.md §4) or use runAcceptance(). Outside ' +
+        "acceptance, use 'flag' or 'error'.",
     );
   }
   const miss = opts.miss ?? 'error';

--- a/packages/core/src/templates/primitives/claude_turn.ts
+++ b/packages/core/src/templates/primitives/claude_turn.ts
@@ -15,7 +15,10 @@ import {
   ProviderTurnUnresumableError,
   type ProviderSessionBinding,
 } from '../../provider_session';
-import { requireConfiguredCapabilityApprovals } from '../../capabilities';
+import {
+  REPLAY_GO_LIVE,
+  requireConfiguredCapabilityApprovals,
+} from '../../capabilities';
 import type { Session, Vars } from '../../session';
 import {
   runExecutionPhase,
@@ -131,7 +134,7 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
       // aggregate output (node-output granularity). Faithful raw replay needs
       // retain: 'full' so the recorded response equals the raw turn result.
       if (runtime?.replay) {
-        return runtime.replay.model({
+        const served = runtime.replay.model({
           nodePath:
             options.nodePath ??
             runtime.recorder?.currentNodePath ??
@@ -139,7 +142,14 @@ export class ClaudeTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
           provider: 'claude',
           requestSession: modelSession,
           requestMeta: claudeRequestMeta,
-        }) as Awaited<ReturnType<typeof collectClaudeAgentTurnResult>>;
+        });
+        // Acceptance `miss: 'live'` (design §4): fall through to the real Claude
+        // turn below when the cassette could not serve this call.
+        if (served !== REPLAY_GO_LIVE) {
+          return served as Awaited<
+            ReturnType<typeof collectClaudeAgentTurnResult>
+          >;
+        }
       }
       const client =
         this.options.client ?? (await createDefaultClaudeAgentClient());

--- a/packages/core/src/templates/primitives/codex_turn.ts
+++ b/packages/core/src/templates/primitives/codex_turn.ts
@@ -23,7 +23,10 @@ import {
   ProviderTurnUnresumableError,
   type ProviderSessionBinding,
 } from '../../provider_session';
-import { requireConfiguredCapabilityApprovals } from '../../capabilities';
+import {
+  REPLAY_GO_LIVE,
+  requireConfiguredCapabilityApprovals,
+} from '../../capabilities';
 import { retainRuntimeEvents } from '../../runtime';
 import type { Session, Vars } from '../../session';
 import {
@@ -149,7 +152,7 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
       // aggregate output (node-output granularity). Faithful raw replay needs
       // retain: 'full' so the recorded response equals the raw turn result.
       if (runtime?.replay) {
-        return runtime.replay.model({
+        const served = runtime.replay.model({
           nodePath:
             options.nodePath ??
             runtime.recorder?.currentNodePath ??
@@ -157,7 +160,12 @@ export class CodexTurn<TVars extends Vars = Vars> extends TemplateBase<TVars> {
           provider: 'codex',
           requestSession: modelSession,
           requestMeta: codexRequestMeta,
-        }) as Awaited<ReturnType<typeof collectCodexTurnResult>>;
+        });
+        // Acceptance `miss: 'live'` (design §4): fall through to the real Codex
+        // turn below when the cassette could not serve this call.
+        if (served !== REPLAY_GO_LIVE) {
+          return served as Awaited<ReturnType<typeof collectCodexTurnResult>>;
+        }
       }
       const ownsClient = this.options.client === undefined;
       const client =

--- a/packages/core/src/templates/primitives/model_runtime.ts
+++ b/packages/core/src/templates/primitives/model_runtime.ts
@@ -1,3 +1,4 @@
+import { REPLAY_GO_LIVE } from '../../capabilities';
 import type { ExecutionEvent, ResolvedExecutionCommand } from '../../execution';
 import {
   type ExecutionPhaseStep,
@@ -100,7 +101,7 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
           // re-run). The recorder below still captures the substituted response
           // into the replay's fresh recording stream.
           if (runtime.replay) {
-            return runtime.replay.model({
+            const served = runtime.replay.model({
               nodePath:
                 record?.nodePath ??
                 runtime.recorder?.currentNodePath ??
@@ -108,7 +109,13 @@ export async function executeRuntimeModelCall<TVars extends Vars, TResult>(
               provider: record?.provider ?? 'assistant',
               requestSession: modelSession,
               requestMeta: record?.requestMeta,
-            }) as TResult;
+            });
+            // Acceptance `miss: 'live'`: the cassette had no entry, so run the
+            // real provider instead of a sentinel (design §4). Any other value
+            // is the served recorded output.
+            if (served !== REPLAY_GO_LIVE) {
+              return served as TResult;
+            }
           }
           return call(request.session);
         },


### PR DESCRIPTION
Fourth replay slice (B0 #68/#69, B1 #71, B2 #72). Past requests cannot exercise behavior that postdates them; acceptance validates NEW behavior forward:

- `replayRun({ acceptance: true, miss: 'live' })`: model misses fall through to the real leaf (REPLAY_GO_LIVE sentinel at the assistant/codex/claude funnels, recorded + flagged live in trace.misses); tool misses STAY SEALED — the asymmetry the design requires for dry-run safety
- `runAcceptance(agent, cases)`: sequential, failure-collecting harness; cases assert on routing/tool-args/structured (deterministic even under live text) plus text; modelStubs/cassette sugar for hermetic cases
- Trust boundary per §6: harness and corpus are trusted-root — claw's corpus lives in repo source (claw/acceptance/) which the self-authoring paths cannot write (they only touch env-configured .data dirs); documented in code
- claw: 5-case builtin corpus + acceptance-runner (pnpm -C claw acceptance), exercised in tests without subprocesses

core 797 unit / claw 42 / all packages, build, lint, prettier green. Remaining in the deploy chain: B5 launcher (lease handoff orchestration — B4 landed as #59/#61).