### PR TITLE
feat: B5 — immutable launcher (blue/green with replay-diff gate)

### DIFF
--- a/claw/package.json
+++ b/claw/package.json
@@ -16,6 +16,7 @@
     "@prompttrail/core": "workspace:*",
     "@prompttrail/cron": "workspace:*",
     "@prompttrail/discord": "workspace:*",
+    "@prompttrail/launcher": "workspace:*",
     "@prompttrail/telegram": "workspace:*",
     "@prompttrail/store-sqlite": "workspace:*",
     "better-sqlite3": "^12.10.0",

--- a/claw/src/deploy-claw.ts
+++ b/claw/src/deploy-claw.ts
@@ -1,0 +1,107 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { ChangeScope, DurableRunStore } from '@prompttrail/core';
+import {
+  deploy,
+  type DeployTarget,
+  type ProbeContext,
+} from '@prompttrail/launcher';
+import { SqliteRunStore } from '@prompttrail/store-sqlite';
+import {
+  buildAcceptanceTarget,
+  builtinCorpus,
+} from '../acceptance/builtin-corpus.js';
+
+/**
+ * Example: deploying claw with the immutable launcher (design-docs
+ * replay-and-self-deploy.md §5, B5). Illustrative wiring — NOT load-bearing in
+ * tests; the launcher's own suite exercises the full promote/rollback flow.
+ *
+ * The launcher is the TRUST ROOT: it never imports the candidate into its own
+ * decision logic. Verification runs over LAUNCHER-OWNED inputs:
+ *   - `corpus.acceptance` = claw's trusted-root acceptance corpus (`builtinCorpus`,
+ *     which lives in `claw/acceptance/`, outside any self-authoring write path);
+ *   - `corpus.runsDir`   = a launcher-owned directory of recorded run fixtures
+ *     (`serializeRunFixture`) to replay-diff against `corpus.scope`;
+ *   - `corpus.scope`     = the declared, trusted-root-authored blast radius.
+ *
+ * The candidate only ever appears as the agent returned by `loadAgent` (a dynamic
+ * import of the candidate's built dist) and as the served child process — it can
+ * never grade itself or seize the lease.
+ */
+export function buildClawDeployTarget(store: DurableRunStore): DeployTarget {
+  // The intended blast radius of THIS deploy, authored by the trusted root. Here:
+  // "only the reply text of the `reply` node may change; routing / tool-args /
+  // control-flow must stay identical." Any diff outside this is a regression.
+  const scope: ChangeScope = {
+    dimensions: ['text'],
+    nodeIds: ['reply'],
+  };
+
+  const clawEntry = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'index.js', // built dist entry (claw/dist/src/index.js)
+  );
+
+  return {
+    name: 'claw',
+    corpus: {
+      // A launcher-owned corpus of recorded StoredRun fixtures. Populate it by
+      // recording production runs with `recording: 'full'` and serializing each
+      // via `serializeRunFixture`. Absent = replay-diff is skipped.
+      runsDir: process.env.CLAW_REPLAY_RUNS_DIR,
+      scope,
+      // Trusted-root acceptance corpus — the SAME cases the acceptance runner
+      // uses, owned outside the mutable build under test.
+      acceptance: builtinCorpus,
+    },
+    // In a real deploy this dynamically imports the CANDIDATE's built dist and
+    // returns its main agent. For this example we reuse the corpus target
+    // builder as a stand-in candidate agent.
+    loadAgent: async (_candidateDir: string) => buildAcceptanceTarget(),
+    // How the launcher serves the green candidate: run claw in lease mode with a
+    // green role. `LAUNCHER_LEASE_HOLDER` + `LAUNCHER_ROLE` are injected by the
+    // launcher; claw's index.ts reads them (CLAW_LEASE opt-in) and WAITS for the
+    // handoff before starting to serve.
+    serve: {
+      command: process.execPath,
+      args: [clawEntry],
+      env: {
+        CLAW_LEASE: '1',
+        CLAW_DB_PATH:
+          process.env.CLAW_DB_PATH ?? join(process.cwd(), '.data', 'claw.db'),
+      },
+    },
+    store,
+    // An independent, launcher-owned health probe: green must hold the lease.
+    probes: [
+      async (ctx: ProbeContext) => {
+        const current = await ctx.store.lease.current();
+        if (current?.holder !== ctx.greenHolder) {
+          throw new Error('green candidate is not the lease holder');
+        }
+      },
+    ],
+  };
+}
+
+async function main(): Promise<void> {
+  const candidateDir = process.argv[2] ?? process.cwd();
+  const store = new SqliteRunStore({
+    // The shared store whose lease arbitrates serving. The launcher owns this
+    // handle; the served children open their own connections to the same file.
+    path: process.env.CLAW_DB_PATH ?? join(process.cwd(), '.data', 'claw.db'),
+    agents: { main: buildAcceptanceTarget() },
+  });
+  const target = buildClawDeployTarget(store);
+  const report = await deploy(candidateDir, target, {
+    healthWindowMs: 5_000,
+    log: (event) => console.log(`[launcher:${event.stage}] ${event.message}`),
+  });
+  console.log(`\nverdict: ${report.verdict}`);
+  process.exitCode = report.verdict === 'promoted' ? 0 : 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/claw/src/index.ts
+++ b/claw/src/index.ts
@@ -161,9 +161,44 @@ const store = new SqliteRunStore({
   path: clawDbPath,
 });
 
+// Single-writer lease (durability §2 / replay-and-self-deploy.md §5, B4/B5).
+// Opt-in via CLAW_LEASE so a bare `claw` run keeps today's zero-config behavior.
+// The holder id comes from the immutable launcher (LAUNCHER_LEASE_HOLDER) so it
+// can TARGET this instance in a blue/green handoff; a plain run falls back to the
+// app's stable default holder. LAUNCHER_ROLE marks blue (the current deployment)
+// vs green (the candidate that must WAIT for the launcher to hand it the lease
+// before it starts serving — see below).
+const leaseEnabled = readBoolean('CLAW_LEASE', false);
+const launcherRole = readOptionalString('LAUNCHER_ROLE');
+const leaseHolder = readOptionalString('LAUNCHER_LEASE_HOLDER');
+let leaseLostHandled = false;
+
 const runtime = PromptTrail.app({
   name: 'claw-discord',
   store,
+  ...(leaseEnabled
+    ? {
+        lease: leaseHolder ? { holder: leaseHolder } : true,
+        onLeaseLost: () => {
+          if (leaseLostHandled) {
+            return;
+          }
+          leaseLostHandled = true;
+          // A newer holder took over (blue lost the lease at a launcher
+          // cutover). Stop the gateways gracefully and exit — the app already
+          // lost the lease, so there is nothing to release; its late writes are
+          // fenced. The exit code marks a lease-driven stop for the launcher.
+          console.warn(
+            `[claw] lost the store lease (holder=${leaseHolder ?? 'default'}); ` +
+              'draining gateways and exiting.',
+          );
+          process.exitCode = 75; // EX_TEMPFAIL: a superseded blue, not a crash
+          void server.stop().catch((error) => {
+            console.error('[claw] error stopping after lease loss', error);
+          });
+        },
+      }
+    : {}),
   defaults: {
     checkpoint: true,
   },
@@ -284,6 +319,15 @@ const server = PromptTrail.server({
   ],
 });
 
+// Green candidate: the launcher holds the lease with blue until it cuts over.
+// The app's lease acquire is fail-fast, so wait until the launcher has handed us
+// the lease (or it is free) before starting — then `server.start()` acquires it,
+// learns its fencing token, and begins serving. Blue skips this and acquires
+// immediately as the current deployment.
+if (leaseEnabled && launcherRole === 'green' && leaseHolder) {
+  await waitForLeaseHandoff(store, leaseHolder);
+}
+
 await server.start();
 
 /**
@@ -347,6 +391,35 @@ function buildSkillReplySource(cfg: ClawConfig): SkillReplySource {
     });
   }
   return Source.callback(async () => '(echo mode: skill reply)');
+}
+
+/**
+ * Green-candidate wait: block until the immutable launcher hands the store lease
+ * to `holder`, so `server.start()`'s (fail-fast) acquire succeeds instead of
+ * racing blue. A FREE lease is deliberately NOT enough — waiting for
+ * `holder === us` guarantees we never steal the lease from blue before the
+ * launcher's verified cutover.
+ */
+async function waitForLeaseHandoff(
+  runStore: SqliteRunStore,
+  holder: string,
+  timeoutMs = 120_000,
+  pollMs = 100,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const current = await runStore.lease.current();
+    if (current && current.holder === holder) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Green candidate timed out after ${timeoutMs}ms waiting for the ` +
+          `launcher to hand off the store lease to "${holder}".`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
 }
 
 function readPackageVersion(): string {

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -1,0 +1,103 @@
+# @prompttrail/launcher
+
+**B5 — the immutable blue/green deploy launcher (the trust root).**
+
+The launcher is the tiny, never-self-modified parent that lets a PromptTrail app
+(e.g. claw) promote a new version of **itself** only after that version is
+verified — then performs the single-writer lease cutover with a health window
+and automatic rollback. It composes the already-merged machinery: B1 replay, B2
+differ + `ChangeScope`, B3 acceptance, B4 store lease + fencing tokens.
+
+Design: `design-docs/replay-and-self-deploy.md` §5 (lease handoff + launcher),
+§6 (trust boundaries), §7 (module boundaries), §8 B5.
+
+## Immutability posture (READ THIS)
+
+The launcher is the **trust root**. Its guarantees only hold if it is installed
+and pinned **outside the candidate's write paths**:
+
+- It **never imports candidate code into its own decision logic.** Verification
+  runs (`verifyCandidate`) execute the candidate agent through the _core_
+  replay/diff/acceptance machinery over **launcher-owned** corpus definitions
+  (`DeployTarget.corpus`). The candidate only ever appears as (a) an `Agent`
+  returned by `loadAgent` and fed _into_ the trusted machinery, and (b) a served
+  child process. It can never grade itself. "Green proposes evidence, the
+  launcher disposes."
+- The **corpus, scope schema, acceptance suite, lease, and launcher itself**
+  live outside what a self-modified build can edit (design §6). claw's
+  self-authoring only ever writes its `.data` dirs — never this package, never
+  `claw/acceptance/`, never the differ/scope schema in core.
+- In a self-modifying deployment, install `@prompttrail/launcher` (and the core
+  differ + acceptance corpus) from a pinned, read-only location. If the candidate
+  could rewrite the launcher, it could weaken its own gate or seize the lease —
+  the whole point is that it cannot.
+
+## Contract (v1)
+
+```ts
+import { deploy } from '@prompttrail/launcher';
+
+const report = await deploy(candidateDir, target, options);
+// report.verdict: 'promoted' | 'rejected' | 'rolled-back'
+```
+
+A `DeployTarget` is a directory + manifest the launcher can VERIFY against and
+SERVE (see `DeployTarget` in the types). Its verification inputs are
+**launcher-owned**, not read from the candidate:
+
+- `corpus.runsDir` — recorded `StoredRun` JSON fixtures (`serializeRunFixture`)
+  replayed for the diff.
+- `corpus.scope` — the declared, trusted-root-authored `ChangeScope`.
+- `corpus.acceptance` — forward fake-request `AcceptanceCase`s.
+- `loadAgent(candidateDir)` — how to load the candidate's agent (e.g. dynamic
+  import of its built dist) for runner-executed verification.
+- `serve` — the command the launcher spawns as the green child.
+- `store` — the shared `DurableRunStore` whose single-writer lease arbitrates
+  serving. The launcher owns this handle and performs the handoff on it directly.
+- `probes` — independent, launcher-owned health checks (throw = unhealthy).
+
+## `deploy()` flow
+
+1. **VERIFY** (sealed, in the launcher process): for each recorded fixture,
+   `buildCassette` + `buildGoldenOutcome`, `replayRun` the candidate agent
+   (`miss: 'flag'`), then `diffReplay` against `scope`. Any **regression** (a
+   diff outside scope) rejects. Then `runAcceptance` — any failure rejects. No
+   child is launched, blue is untouched.
+2. **LAUNCH green**: spawn `serve` as a canary child. It comes up warm (its own
+   store/lease config) and does not serve until handed the lease.
+3. **CUTOVER**: discover blue via `store.lease.current()`, then
+   `store.lease.handoff({ from: blue, to: green })` — atomic. Fencing tokens make
+   a drained blue's late writes fail safely (`FencingTokenError`).
+4. **HEALTH WINDOW**: confirm green took over (probes pass) and stays healthy for
+   `healthWindowMs`. A probe failure hands the lease **back** to the still-warm
+   blue and kills green → `rolled-back`.
+5. **PROMOTE**: signal blue (via `options.current`) to drain + exit → `promoted`.
+
+Any exception drives a **safe state**: blue keeps/regains the lease, green is
+killed, verdict `rejected`.
+
+## Handoff mechanism (v1 decision)
+
+The launcher owns the `store` handle and performs the lease transfer **directly**
+via `store.lease.handoff({ from, to, ttlMs })` — it does not itself hold the
+lease. `from` is discovered with `store.lease.current()`; `to` is the holder id
+the launcher assigned to green (injected as `LAUNCHER_LEASE_HOLDER`). Because
+`handoff` bumps the monotonic fencing token, a paused/late blue presenting its
+old token is rejected by every mutating store method (the B4 guarantee).
+
+The **green child must wait for the handoff** before it starts serving: the
+app's built-in lease acquire is fail-fast, so a green candidate polls
+`store.lease.current()` until it is the holder, then `start()` acquires (renews
+as the active holder, learning its token) and serves. Blue stays **warm** through
+the health window (it drops to standby on lease loss rather than exiting), so a
+rollback is an instant handoff back, not a cold restart. See claw's
+`waitForLeaseHandoff` and `onLeaseLost` wiring (`claw/src/index.ts`) and the
+scripted child in `src/__tests__/children/server-child.mjs`.
+
+## Blue-side support (claw)
+
+claw opts into lease mode with `CLAW_LEASE=1`; the holder id comes from
+`LAUNCHER_LEASE_HOLDER`, and `LAUNCHER_ROLE=green` makes it wait for the handoff
+before serving. `onLeaseLost` stops the gateways gracefully and exits with code
+75 (a superseded blue, not a crash). See `claw/src/deploy-claw.ts` for the full
+wiring, using claw's trusted acceptance corpus as the acceptance input.

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@prompttrail/launcher",
+  "version": "0.0.1",
+  "description": "Immutable blue/green deploy launcher (trust root) for PromptTrail",
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rm -f tsconfig.tsbuildinfo && tsup && tsc --emitDeclarationOnly -p tsconfig.json",
+    "test": "vitest --run --watch=false",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest watch",
+    "lint": "cd ../.. && ./node_modules/.bin/eslint packages/launcher/src",
+    "lint:fix": "cd ../.. && ./node_modules/.bin/eslint packages/launcher/src --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist coverage",
+    "prepublishOnly": "pnpm run clean && pnpm run build"
+  },
+  "dependencies": {
+    "@prompttrail/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@prompttrail/store-sqlite": "workspace:*",
+    "@types/node": "^20.17.19",
+    "@vitest/coverage-v8": "^1.6.1",
+    "tsup": "^8.3.6",
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  }
+}

--- a/packages/launcher/src/__tests__/children/server-child.mjs
+++ b/packages/launcher/src/__tests__/children/server-child.mjs
@@ -1,0 +1,149 @@
+// Scripted server child for the launcher blue/green tests.
+//
+// This stands in for a real deployable (e.g. claw). It is deliberately tiny: it
+// only participates in the single-writer lease and demonstrates fencing, because
+// that is all the launcher orchestration needs from a served process. The store
+// family is the cross-process IPC (design task step 4): both children open their
+// OWN SqliteRunStore on the SAME db file, so the lease row is shared.
+//
+// Symmetric warm-standby protocol (so rollback keeps blue warm):
+//   - I SERVE while I hold the lease (holder === me): I (re)acquire to learn my
+//     fencing token and heartbeat it.
+//   - When someone else holds the lease I drop to STANDBY. On the transition out
+//     of serving I fire ONE "late write" with my now-stale token to prove the
+//     store fences it out (the B4 guarantee) and record the outcome.
+//   - I re-take the lease the instant it is handed (back) to me (holder === me).
+//   - blue takes the lease on startup (it is the current deployment); green
+//     starts in standby and only serves once the launcher hands it the lease.
+//
+// It imports the BUILT @prompttrail/store-sqlite (a spawned process gets no
+// vitest source aliases), so the workspace must be built — which the launcher's
+// verify step ensures.
+import { writeFileSync, renameSync } from 'node:fs';
+import { SqliteRunStore } from '@prompttrail/store-sqlite';
+
+const holder = process.env.LAUNCHER_LEASE_HOLDER;
+const role = process.env.LAUNCHER_ROLE;
+const ttlMs = Number(process.env.LAUNCHER_TTL_MS ?? '30000');
+const dbPath = process.env.LAUNCHER_DB_PATH;
+const readyFile = process.env.LAUNCHER_READY_FILE;
+const statusFile = process.env.LAUNCHER_STATUS_FILE;
+const pollMs = Number(process.env.LAUNCHER_POLL_MS ?? '50');
+
+if (!holder || !dbPath || !statusFile) {
+  console.error('server-child: missing required env');
+  process.exit(2);
+}
+
+const store = new SqliteRunStore({ path: dbPath, agents: {} });
+
+let token; // fencing token I currently hold, if serving
+let serving = false;
+let everServed = false;
+let lateWriteRejected = null; // null=untested, true=fenced out, false=leaked
+
+function writeStatus() {
+  const tmp = `${statusFile}.tmp`;
+  writeFileSync(
+    tmp,
+    JSON.stringify({
+      holder,
+      role,
+      serving,
+      token: token ?? null,
+      lateWriteRejected,
+      pid: process.pid,
+      at: Date.now(),
+    }),
+  );
+  renameSync(tmp, statusFile);
+}
+
+async function fenceProbe(staleToken) {
+  // Present a stale fencing token to a mutating store method. `patch` runs the
+  // fence check FIRST, so a stale token throws FencingTokenError before touching
+  // any run — a clean, side-effect-free demonstration of the drained-blue guard.
+  try {
+    await store.patch('launcher-fence-probe', { status: 'open' }, staleToken);
+    lateWriteRejected = false;
+  } catch (error) {
+    lateWriteRejected = error && error.name === 'FencingTokenError';
+  }
+}
+
+async function tick() {
+  let current;
+  try {
+    current = await store.lease.current();
+  } catch {
+    return;
+  }
+
+  if (current && current.holder === holder) {
+    // I am (or have just been handed) the holder: (re)acquire renews and keeps
+    // the token, teaching me my fence so my writes pass and blue's don't.
+    const state = await store.lease.acquire(holder, ttlMs);
+    if (state) {
+      token = state.token;
+      serving = true;
+      everServed = true;
+    }
+  } else if (!current) {
+    // Lease is free (nobody active).
+    if (role === 'blue' && !everServed) {
+      // Blue is the current deployment: take the lease on startup.
+      const state = await store.lease.acquire(holder, ttlMs);
+      if (state) {
+        token = state.token;
+        serving = true;
+        everServed = true;
+      }
+    } else if (serving) {
+      // I was serving and my lease lapsed: re-take it (keeps me warm).
+      const state = await store.lease.acquire(holder, ttlMs);
+      if (state) {
+        token = state.token;
+      }
+    }
+    // Green pre-cutover with a free lease: stay in standby, never steal it.
+  } else {
+    // Someone else holds the lease.
+    if (serving) {
+      // I just lost it. Prove my stale token is fenced out, then stand by warm.
+      serving = false;
+      const stale = token;
+      if (stale !== undefined) {
+        await fenceProbe(stale);
+      }
+    }
+  }
+
+  writeStatus();
+}
+
+let looping = false;
+const timer = setInterval(() => {
+  if (looping) return;
+  looping = true;
+  void tick().finally(() => {
+    looping = false;
+  });
+}, pollMs);
+
+function shutdown() {
+  clearInterval(timer);
+  try {
+    writeStatus();
+  } catch {
+    // ignore
+  }
+  process.exit(0);
+}
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+
+// Warm + connected: run one tick (blue grabs the lease here) then signal ready.
+await tick();
+if (readyFile) {
+  writeFileSync(readyFile, String(process.pid));
+}

--- a/packages/launcher/src/__tests__/deploy.test.ts
+++ b/packages/launcher/src/__tests__/deploy.test.ts
@@ -1,0 +1,306 @@
+import { mkdtempSync, promises as fs, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Agent, MemoryRunStore, PromptTrail, Source } from '@prompttrail/core';
+import type { AcceptanceCase, ChangeScope } from '@prompttrail/core';
+import { SqliteRunStore } from '@prompttrail/store-sqlite';
+import { deploy } from '../deploy';
+import { launchServer } from '../process';
+import { serializeRunFixture } from '../fixtures';
+import type { DeployTarget, LaunchedProcess, ProbeContext } from '../types';
+
+const CHILD = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'children',
+  'server-child.mjs',
+);
+
+// ── fixtures + agents ───────────────────────────────────────────────────────
+
+/** Baseline service agent: inbox → assistant('reply'). */
+function serviceAgent() {
+  return Agent.create('svc')
+    .inbox('inbound')
+    .assistant('reply', Source.llm().mock().mockResponse({ content: 'hello' }));
+}
+
+/**
+ * A structurally DIVERGED candidate: an extra system node changes the executed
+ * node path (control-flow), so replay against the fixture flags an out-of-scope
+ * regression when the scope only permits `text`.
+ */
+function divergedAgent() {
+  return Agent.create('svc')
+    .inbox('inbound')
+    .system('injected', 'extra node not present in the recording')
+    .assistant('reply', Source.llm().mock().mockResponse({ content: 'hello' }));
+}
+
+async function writeFixture(runsDir: string): Promise<void> {
+  const store = new MemoryRunStore();
+  const app = PromptTrail.app({
+    agents: { svc: serviceAgent() },
+    store,
+    recording: 'full',
+  });
+  await app.run({ agent: 'svc', runId: 'r1', input: 'hi', checkpoint: true });
+  const run = await store.get('r1');
+  if (!run) throw new Error('fixture run not stored');
+  await fs.mkdir(runsDir, { recursive: true });
+  await fs.writeFile(join(runsDir, 'r1.json'), serializeRunFixture(run));
+}
+
+// scope: only the `text` dimension may change, only on the `reply` node.
+const TEXT_ONLY_SCOPE: ChangeScope = {
+  dimensions: ['text'],
+  nodeIds: ['reply'],
+};
+
+const GREETS: AcceptanceCase = {
+  name: 'greets',
+  inbox: ['hi'],
+  modelStubs: ['hello there'],
+  assert: (trace) => {
+    const text = trace.finalReply.map((m) => m.content).join('');
+    if (!text.includes('hello')) {
+      throw new Error(`expected a greeting, got: ${text}`);
+    }
+  },
+};
+
+// ── test harness (temp dir + child reaping) ─────────────────────────────────
+
+interface Ctx {
+  dir: string;
+  dbPath: string;
+  runsDir: string;
+  store: SqliteRunStore;
+  children: LaunchedProcess[];
+  pids: number[];
+}
+
+let ctx: Ctx;
+
+function readyFile(dir: string, name: string): string {
+  return join(dir, `${name}.ready`);
+}
+function statusFile(dir: string, name: string): string {
+  return join(dir, `${name}.status`);
+}
+
+beforeEach(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'launcher-test-'));
+  const dbPath = join(dir, 'store.db');
+  const runsDir = join(dir, 'runs');
+  await writeFixture(runsDir);
+  const store = new SqliteRunStore({ path: dbPath, agents: {} });
+  ctx = { dir, dbPath, runsDir, store, children: [], pids: [] };
+});
+
+afterEach(async () => {
+  // Reap EVERY spawned child so no dangling processes/handles leak.
+  for (const child of ctx.children) {
+    child.kill();
+  }
+  for (const pid of ctx.pids) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+  // Give SIGKILL a beat to land before removing the db file.
+  await new Promise((r) => setTimeout(r, 50));
+  rmSync(ctx.dir, { recursive: true, force: true });
+});
+
+function buildTarget(overrides: Partial<DeployTarget> = {}): DeployTarget {
+  return {
+    name: 'svc',
+    corpus: {
+      runsDir: ctx.runsDir,
+      scope: TEXT_ONLY_SCOPE,
+      acceptance: [GREETS],
+    },
+    loadAgent: async () => serviceAgent(),
+    serve: {
+      command: process.execPath,
+      args: [CHILD],
+      env: { LAUNCHER_DB_PATH: ctx.dbPath, LAUNCHER_POLL_MS: '40' },
+    },
+    store: ctx.store,
+    ...overrides,
+  };
+}
+
+/** Launch the blue (current) deployment and wait until it holds the lease. */
+async function startBlue(target: DeployTarget): Promise<LaunchedProcess> {
+  const blue = launchServer(target, {
+    holder: 'svc-blue',
+    role: 'blue',
+    ttlMs: 30_000,
+    readyFile: readyFile(ctx.dir, 'blue'),
+    statusFile: statusFile(ctx.dir, 'blue'),
+  });
+  ctx.children.push(blue);
+  await blue.waitReady(5_000);
+  await waitFor(async () => {
+    const cur = await ctx.store.lease.current();
+    return cur?.holder === 'svc-blue';
+  }, 5_000);
+  return blue;
+}
+
+async function readStatus(file: string): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(file, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() >= deadline) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+// A launcher-owned probe: green must be serving AND actually hold the lease.
+const servingProbe = async (probeCtx: ProbeContext): Promise<void> => {
+  const st = await readStatus(probeCtx.statusFile);
+  if (st.serving !== true) throw new Error('green not serving yet');
+  const cur = await probeCtx.store.lease.current();
+  if (cur?.holder !== probeCtx.greenHolder) {
+    throw new Error('green does not hold the lease');
+  }
+};
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+describe('deploy() — B5 launcher', () => {
+  it('promotes a clean candidate: handoff, health passes, blue fenced + exits', async () => {
+    const target = buildTarget();
+    const blue = await startBlue(target);
+
+    const report = await deploy(ctx.dir, target, {
+      current: blue,
+      ttlMs: 30_000,
+      healthWindowMs: 200,
+      probeIntervalMs: 40,
+      readyTimeoutMs: 5_000,
+      probes: [servingProbe],
+    });
+    if (report.stages.launch?.pid) ctx.pids.push(report.stages.launch.pid);
+
+    expect(report.verdict).toBe('promoted');
+    expect(report.stages.verify?.ok).toBe(true);
+    expect(report.stages.cutover?.ok).toBe(true);
+
+    const greenHolder = report.stages.cutover?.to;
+    const cur = await ctx.store.lease.current();
+    expect(cur?.holder).toBe(greenHolder);
+
+    // Blue lost the lease at cutover; its stale-token write was fenced (B4).
+    const blueStatus = await readStatus(statusFile(ctx.dir, 'blue'));
+    expect(blueStatus.lateWriteRejected).toBe(true);
+
+    // Blue was signaled to drain + exit.
+    await waitFor(async () => blue.exited, 5_000);
+    expect(blue.exited).toBe(true);
+  });
+
+  it('rejects a regression before touching blue (no green launched)', async () => {
+    const target = buildTarget({ loadAgent: async () => divergedAgent() });
+    const blue = await startBlue(target);
+
+    const report = await deploy(ctx.dir, target, {
+      current: blue,
+      probes: [servingProbe],
+    });
+
+    expect(report.verdict).toBe('rejected');
+    expect(report.stages.verify?.ok).toBe(false);
+    expect(report.stages.verify?.regressions).toBeGreaterThan(0);
+    expect(report.diffs?.some((d) => d.kind === 'regression')).toBe(true);
+    // No green process was ever spawned.
+    expect(report.stages.launch).toBeUndefined();
+    // Blue is untouched and still holds the lease.
+    expect(blue.exited).toBe(false);
+    const cur = await ctx.store.lease.current();
+    expect(cur?.holder).toBe('svc-blue');
+  });
+
+  it('rejects on acceptance failure before touching blue', async () => {
+    const failing: AcceptanceCase = {
+      name: 'unmet-expectation',
+      inbox: ['hi'],
+      modelStubs: ['hello'],
+      assert: () => {
+        throw new Error('forced acceptance failure');
+      },
+    };
+    const target = buildTarget({
+      corpus: {
+        runsDir: ctx.runsDir,
+        scope: TEXT_ONLY_SCOPE,
+        acceptance: [failing],
+      },
+    });
+    const blue = await startBlue(target);
+
+    const report = await deploy(ctx.dir, target, {
+      current: blue,
+      probes: [servingProbe],
+    });
+
+    expect(report.verdict).toBe('rejected');
+    expect(report.stages.verify?.acceptanceOk).toBe(false);
+    expect(report.acceptance?.ok).toBe(false);
+    expect(report.stages.launch).toBeUndefined();
+    expect(blue.exited).toBe(false);
+    const cur = await ctx.store.lease.current();
+    expect(cur?.holder).toBe('svc-blue');
+  });
+
+  it('rolls back when the health window fails: lease handed back to warm blue', async () => {
+    const target = buildTarget({
+      // An independent launcher probe that always reports green unhealthy.
+      probes: [
+        async () => {
+          throw new Error('simulated degradation');
+        },
+      ],
+    });
+    const blue = await startBlue(target);
+
+    const report = await deploy(ctx.dir, target, {
+      current: blue,
+      ttlMs: 30_000,
+      healthWindowMs: 200,
+      probeIntervalMs: 40,
+      // Short confirm window so the failing probe rolls back quickly.
+      readyTimeoutMs: 700,
+    });
+    if (report.stages.launch?.pid) ctx.pids.push(report.stages.launch.pid);
+
+    expect(report.verdict).toBe('rolled-back');
+    expect(report.stages.cutover?.ok).toBe(true);
+    expect(report.stages.health?.ok).toBe(false);
+    expect(report.stages.health?.rolledBack).toBe(true);
+
+    // Blue holds the lease again and never exited (stayed warm).
+    const cur = await ctx.store.lease.current();
+    expect(cur?.holder).toBe('svc-blue');
+    expect(blue.exited).toBe(false);
+    // Blue resumes serving after the rollback handoff.
+    await waitFor(async () => {
+      const st = await readStatus(statusFile(ctx.dir, 'blue'));
+      return st.serving === true;
+    }, 5_000);
+  });
+});

--- a/packages/launcher/src/__tests__/fixtures.test.ts
+++ b/packages/launcher/src/__tests__/fixtures.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Agent,
+  buildCassette,
+  buildGoldenOutcome,
+  MemoryRunStore,
+  PromptTrail,
+  Source,
+} from '@prompttrail/core';
+import type { StoredRun } from '@prompttrail/core';
+import { deserializeRunFixture, serializeRunFixture } from '../fixtures';
+
+function serviceAgent(reply = 'hello') {
+  return Agent.create('svc')
+    .inbox('inbound')
+    .assistant('reply', Source.llm().mock().mockResponse({ content: reply }));
+}
+
+async function recordRun(): Promise<StoredRun<any>> {
+  const store = new MemoryRunStore();
+  const app = PromptTrail.app({
+    agents: { svc: serviceAgent() },
+    store,
+    recording: 'full',
+  });
+  await app.run({ agent: 'svc', runId: 'r1', input: 'hi', checkpoint: true });
+  const run = await store.get('r1');
+  if (!run) throw new Error('run not stored');
+  return run;
+}
+
+describe('run fixture serialization', () => {
+  it('round-trips a recorded run minus its agent, and stays replayable', async () => {
+    const run = await recordRun();
+    const json = serializeRunFixture(run);
+
+    // Serializable JSON, no agent leaked.
+    const parsed = JSON.parse(json);
+    expect(parsed.agent).toBeUndefined();
+    expect(parsed.agentName).toBe('svc');
+    expect(Array.isArray(parsed.recording)).toBe(true);
+    expect(parsed.recording.length).toBeGreaterThan(0);
+
+    const fixture = deserializeRunFixture(json);
+    expect(fixture.agent).toBeUndefined();
+
+    // The reconstructed fixture drives the same cassette + golden the original
+    // did — the agent is re-supplied separately at verify time.
+    const withAgent = { ...fixture, agent: serviceAgent() as any };
+    const cassette = buildCassette(withAgent);
+    expect(cassette.model.length).toBeGreaterThan(0);
+    const golden = buildGoldenOutcome(withAgent);
+    expect(golden.finalReply.map((m) => m.content).join('')).toContain('hello');
+  });
+});

--- a/packages/launcher/src/deploy.ts
+++ b/packages/launcher/src/deploy.ts
@@ -1,0 +1,388 @@
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { delay, launchServer } from './process';
+import { verifyCandidate } from './verify';
+import type {
+  DeployLogEvent,
+  DeployOptions,
+  DeployReport,
+  DeployTarget,
+  LaunchedProcess,
+  ProbeContext,
+} from './types';
+
+const DEFAULTS = {
+  ttlMs: 30_000,
+  healthWindowMs: 3_000,
+  drainTimeoutMs: 5_000,
+  probeIntervalMs: 200,
+  readyTimeoutMs: 10_000,
+};
+
+/**
+ * Verify a candidate and, only if it passes, cut the single-writer lease over to
+ * it — with a post-cutover health window and automatic rollback (design §5,
+ * corrected). The launcher is the decision-maker: green (the candidate) only
+ * ever supplies EVIDENCE (a loaded agent for verification, a live process for
+ * probing); every irreversible step (handoff, rollback, promote) is executed
+ * here, by the trusted root.
+ *
+ * Flow:
+ *  a. VERIFY (sealed, in-process): replay-diff over the launcher-owned corpus +
+ *     acceptance. Any regression / acceptance failure → 'rejected', blue
+ *     untouched, no child ever launched.
+ *  b. LAUNCH green: spawn `target.serve` as a canary child (its own store/lease
+ *     config; the launcher injects only role + green holder id). It comes up
+ *     WARM and polls the lease, but does not serve until it is handed the lease.
+ *  c. CUTOVER: discover blue via `store.lease.current()`, then
+ *     `store.lease.handoff({ from: blue, to: green })` — atomic; fencing makes a
+ *     drained blue's late writes fail safely.
+ *  d. HEALTH WINDOW: confirm green took over (probes pass) and stays healthy for
+ *     `healthWindowMs`. A probe failure → handoff back to the still-warm blue,
+ *     kill green → 'rolled-back'.
+ *  e. PROMOTE: signal blue to drain + exit → 'promoted'.
+ *
+ * Any exception drives a SAFE STATE: blue keeps/regains the lease, green is
+ * killed, verdict 'rejected'.
+ */
+export async function deploy(
+  candidateDir: string,
+  target: DeployTarget,
+  opts: DeployOptions = {},
+): Promise<DeployReport> {
+  const ttlMs = opts.ttlMs ?? DEFAULTS.ttlMs;
+  const healthWindowMs = opts.healthWindowMs ?? DEFAULTS.healthWindowMs;
+  const drainTimeoutMs = opts.drainTimeoutMs ?? DEFAULTS.drainTimeoutMs;
+  const probeIntervalMs = opts.probeIntervalMs ?? DEFAULTS.probeIntervalMs;
+  const readyTimeoutMs = opts.readyTimeoutMs ?? DEFAULTS.readyTimeoutMs;
+  const now = opts.now ?? Date.now;
+  const store = target.store;
+  const probes = target.probes ?? [];
+  const log = (
+    stage: DeployLogEvent['stage'],
+    message: string,
+    data?: Record<string, unknown>,
+  ) => opts.log?.({ stage, message, at: now(), data });
+
+  const report: DeployReport = {
+    verdict: 'rejected',
+    target: target.name,
+    stages: {},
+  };
+
+  // ── a. VERIFY (sealed, launcher process) ─────────────────────────────────
+  let agent;
+  try {
+    agent = await target.loadAgent(candidateDir);
+    const verify = await verifyCandidate(agent, target.corpus);
+    report.stages.verify = {
+      ok: verify.ok,
+      fixtures: verify.diffs.length,
+      regressions: verify.regressions,
+      acceptanceOk: verify.acceptance?.ok,
+    };
+    report.diffs = verify.diffs;
+    report.acceptance = verify.acceptance;
+    if (!verify.ok) {
+      log('verify', 'candidate rejected by verification; blue untouched', {
+        regressions: verify.regressions,
+        acceptanceOk: verify.acceptance?.ok,
+      });
+      report.verdict = 'rejected';
+      return report;
+    }
+    log('verify', 'candidate passed verification', {
+      fixtures: verify.diffs.length,
+    });
+  } catch (error) {
+    report.stages.verify = {
+      ok: false,
+      fixtures: 0,
+      regressions: 0,
+      error: errMessage(error),
+    };
+    report.verdict = 'rejected';
+    report.error = errMessage(error);
+    log('verify', 'verification threw; blue untouched', {
+      error: errMessage(error),
+    });
+    return report;
+  }
+
+  // ── b. LAUNCH green ──────────────────────────────────────────────────────
+  const greenHolder = `${target.name}-green-${process.pid}-${now()}`;
+  const readyFile = tempFile('ready');
+  const statusFile = tempFile('status');
+  const probeCtx: ProbeContext = { greenHolder, statusFile, store };
+  let green: LaunchedProcess | undefined;
+  try {
+    green = launchServer(target, {
+      holder: greenHolder,
+      role: 'green',
+      ttlMs,
+      readyFile,
+      statusFile,
+    });
+    await green.waitReady(readyTimeoutMs);
+    report.stages.launch = { ok: true, holder: greenHolder, pid: green.pid };
+    log('launch', 'green launched and ready (warm, not yet serving)', {
+      holder: greenHolder,
+      pid: green.pid,
+    });
+  } catch (error) {
+    green?.kill();
+    await cleanup([readyFile, statusFile]);
+    report.stages.launch = { ok: false, error: errMessage(error) };
+    report.verdict = 'rejected';
+    report.error = errMessage(error);
+    log('launch', 'green failed to launch; blue untouched', {
+      error: errMessage(error),
+    });
+    return report;
+  }
+
+  // From here, cutover is possible, so every failure must reach a safe state.
+  let blueHolder: string | undefined;
+  let handedOff = false;
+  try {
+    // ── c. CUTOVER ─────────────────────────────────────────────────────────
+    const current = await store.lease.current();
+    if (!current) {
+      throw new Error(
+        'no live lease holder to hand off from (blue is not holding the lease)',
+      );
+    }
+    blueHolder = current.holder;
+    log(
+      'drain',
+      'draining blue via lease handoff (fencing seals late writes)',
+      {
+        blue: blueHolder,
+      },
+    );
+    const handed = await store.lease.handoff({
+      from: blueHolder,
+      to: greenHolder,
+      ttlMs,
+    });
+    if (!handed) {
+      throw new Error(
+        `handoff rejected: "${blueHolder}" is no longer the current holder`,
+      );
+    }
+    handedOff = true;
+    report.stages.cutover = {
+      ok: true,
+      from: blueHolder,
+      to: greenHolder,
+      token: handed.token,
+    };
+    log('cutover', 'lease handed off blue → green', {
+      from: blueHolder,
+      to: greenHolder,
+      token: handed.token,
+    });
+
+    // ── d. HEALTH WINDOW ─────────────────────────────────────────────────────
+    // Confirm green actually took over (probes must pass at least once), then
+    // watch that it STAYS healthy for the window. Either failure rolls back.
+    const tookOver = await waitUntilHealthy(
+      probes,
+      probeCtx,
+      readyTimeoutMs,
+      probeIntervalMs,
+    );
+    if (!tookOver.ok) {
+      return await rollback(
+        report,
+        store,
+        greenHolder,
+        blueHolder,
+        ttlMs,
+        green,
+        [readyFile, statusFile],
+        `green did not become healthy after cutover: ${tookOver.error}`,
+        log,
+      );
+    }
+    const sustained = await sustainHealthy(
+      probes,
+      probeCtx,
+      healthWindowMs,
+      probeIntervalMs,
+    );
+    if (!sustained.ok) {
+      return await rollback(
+        report,
+        store,
+        greenHolder,
+        blueHolder,
+        ttlMs,
+        green,
+        [readyFile, statusFile],
+        `green degraded during the health window: ${sustained.error}`,
+        log,
+      );
+    }
+    report.stages.health = { ok: true };
+    log('health', 'green healthy through the window', {
+      windowMs: healthWindowMs,
+    });
+
+    // ── e. PROMOTE ───────────────────────────────────────────────────────────
+    let blueStopped = false;
+    if (opts.current) {
+      // Blue lost the lease at cutover; app.stop releases nothing — it just exits.
+      await opts.current.stop(drainTimeoutMs);
+      blueStopped = true;
+    }
+    report.stages.promote = { ok: true, blueStopped };
+    report.verdict = 'promoted';
+    log('promote', 'blue drained + exited; green is the live writer', {
+      green: greenHolder,
+      blueStopped,
+    });
+    await cleanup([readyFile, statusFile]);
+    return report;
+  } catch (error) {
+    // ── SAFE STATE ───────────────────────────────────────────────────────────
+    // Ensure blue holds the lease again (only meaningful if we handed off), and
+    // kill green. Blue was left warm, so it re-takes the lease on the next tick.
+    if (handedOff && blueHolder) {
+      try {
+        await store.lease.handoff({
+          from: greenHolder,
+          to: blueHolder,
+          ttlMs,
+        });
+      } catch {
+        // best-effort: if green already lost the lease, blue recovers via expiry
+      }
+    }
+    green.kill();
+    await cleanup([readyFile, statusFile]);
+    report.stages.health = report.stages.health ?? {
+      ok: false,
+      error: errMessage(error),
+    };
+    report.verdict = 'rejected';
+    report.error = errMessage(error);
+    log('safe-state', 'exception during cutover; reverted to blue', {
+      error: errMessage(error),
+      revertedToBlue: handedOff && !!blueHolder,
+    });
+    return report;
+  }
+}
+
+/** Hand the lease back to the warm blue, kill green, and mark 'rolled-back'. */
+async function rollback(
+  report: DeployReport,
+  store: DeployTarget['store'],
+  greenHolder: string,
+  blueHolder: string,
+  ttlMs: number,
+  green: LaunchedProcess,
+  tempFiles: string[],
+  reason: string,
+  log: (
+    stage: DeployLogEvent['stage'],
+    message: string,
+    data?: Record<string, unknown>,
+  ) => void,
+): Promise<DeployReport> {
+  const back = await store.lease.handoff({
+    from: greenHolder,
+    to: blueHolder,
+    ttlMs,
+  });
+  green.kill();
+  await cleanup(tempFiles);
+  report.stages.health = {
+    ok: false,
+    error: reason,
+    rolledBack: Boolean(back),
+  };
+  report.verdict = 'rolled-back';
+  log('rollback', 'health window failed; lease handed back green → blue', {
+    reason,
+    to: blueHolder,
+    token: back?.token,
+  });
+  return report;
+}
+
+/** Poll the probes until they ALL pass once, or the deadline elapses. */
+async function waitUntilHealthy(
+  probes: NonNullable<DeployTarget['probes']>,
+  ctx: ProbeContext,
+  timeoutMs: number,
+  intervalMs: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = 'unknown';
+  for (;;) {
+    const result = await runProbes(probes, ctx);
+    if (result.ok) {
+      return { ok: true };
+    }
+    lastError = result.error ?? 'unknown';
+    if (Date.now() >= deadline) {
+      return { ok: false, error: lastError };
+    }
+    await delay(intervalMs);
+  }
+}
+
+/** Run the probes repeatedly for `windowMs`; ANY failure ends unhealthy. */
+async function sustainHealthy(
+  probes: NonNullable<DeployTarget['probes']>,
+  ctx: ProbeContext,
+  windowMs: number,
+  intervalMs: number,
+): Promise<{ ok: boolean; error?: string }> {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    const result = await runProbes(probes, ctx);
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+    if (Date.now() >= deadline) {
+      return { ok: true };
+    }
+    await delay(intervalMs);
+  }
+}
+
+async function runProbes(
+  probes: NonNullable<DeployTarget['probes']>,
+  ctx: ProbeContext,
+): Promise<{ ok: boolean; error?: string }> {
+  for (const probe of probes) {
+    try {
+      await probe(ctx);
+    } catch (error) {
+      return { ok: false, error: errMessage(error) };
+    }
+  }
+  return { ok: true };
+}
+
+function tempFile(kind: string): string {
+  return join(
+    tmpdir(),
+    `prompttrail-launcher-${kind}-${randomBytes(8).toString('hex')}`,
+  );
+}
+
+async function cleanup(files: string[]): Promise<void> {
+  await Promise.all(
+    files.map((file) => fs.rm(file, { force: true }).catch(() => undefined)),
+  );
+}
+
+function errMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/launcher/src/fixtures.ts
+++ b/packages/launcher/src/fixtures.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { createSession, Session } from '@prompttrail/core';
+import type { StoredRun } from '@prompttrail/core';
+
+/**
+ * Replay-diff fixtures: a recorded {@link StoredRun} serialized to JSON so it
+ * can live in a launcher-owned corpus directory and be replayed against a
+ * candidate agent later (design §1/§5, task step 4).
+ *
+ * A live `StoredRun` carries an `agent` (a closure graph — NOT serializable) and
+ * an `once` memo store. The fixture drops both: the AGENT is re-supplied at
+ * verify time by `DeployTarget.loadAgent` (the candidate under test), and the
+ * once store is irrelevant to replay/diff (the replay executor drives everything
+ * from the recording + inbox and never reads `run.once`). What the fixture keeps
+ * is exactly what `buildCassette` / `buildGoldenOutcome` / `replayRun` consume:
+ * `recording`, `recordLevel`, `initial`/`result` sessions, `inbox`, `outbox`,
+ * `services`.
+ */
+export interface RunFixture {
+  agentName: string;
+  status: StoredRun<any>['status'];
+  recordLevel?: StoredRun<any>['recordLevel'];
+  initial: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  inbox: StoredRun<any>['inbox'];
+  outbox: StoredRun<any>['outbox'];
+  services?: StoredRun<any>['services'];
+  recording: StoredRun<any>['recording'];
+}
+
+/** Serialize a recorded run to a fixture JSON string (drops `agent` + `once`). */
+export function serializeRunFixture(run: StoredRun<any>): string {
+  const fixture: RunFixture = {
+    agentName: run.agentName,
+    status: run.status,
+    recordLevel: run.recordLevel,
+    initial: run.initial.toJSON(),
+    result: run.result ? run.result.toJSON() : undefined,
+    inbox: run.inbox ?? [],
+    outbox: run.outbox ?? [],
+    services: run.services,
+    recording: run.recording,
+  };
+  return JSON.stringify(fixture, null, 2);
+}
+
+/**
+ * Reconstruct a {@link StoredRun} from a fixture. The `agent` field is left
+ * undefined — the caller MUST attach the candidate agent (from `loadAgent`)
+ * before replaying, and always passes it explicitly as `replayRun`'s `agent`
+ * option so `run.agent` is never dereferenced.
+ */
+export function deserializeRunFixture(json: string): StoredRun<any> {
+  const fixture = JSON.parse(json) as RunFixture;
+  return {
+    // Re-supplied by the caller via DeployTarget.loadAgent (never read here).
+    agent: undefined as unknown as StoredRun<any>['agent'],
+    agentName: fixture.agentName,
+    status: fixture.status ?? 'done',
+    recordLevel: fixture.recordLevel,
+    initial: fixture.initial
+      ? Session.fromJSON(fixture.initial)
+      : createSession(),
+    result: fixture.result ? Session.fromJSON(fixture.result) : undefined,
+    // Replay/diff never touch `once`; a fresh empty memo satisfies the type.
+    once: { run: new Map(), conversation: new Map() },
+    outbox: fixture.outbox ?? [],
+    inbox: fixture.inbox ?? [],
+    services: fixture.services,
+    recording: fixture.recording,
+  };
+}
+
+/** One loaded fixture: its file stem (used as the diff label) + the run. */
+export interface LoadedFixture {
+  name: string;
+  run: StoredRun<any>;
+}
+
+/**
+ * Read every `*.json` fixture in `runsDir` (sorted by name for a stable corpus
+ * order) and reconstruct each into a {@link StoredRun}. A missing directory
+ * yields an empty corpus.
+ */
+export async function readRunFixtures(
+  runsDir: string,
+): Promise<LoadedFixture[]> {
+  let names: string[];
+  try {
+    names = await fs.readdir(runsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+  const jsonFiles = names.filter((name) => name.endsWith('.json')).sort();
+  const fixtures: LoadedFixture[] = [];
+  for (const file of jsonFiles) {
+    const raw = await fs.readFile(join(runsDir, file), 'utf8');
+    fixtures.push({
+      name: file.replace(/\.json$/, ''),
+      run: deserializeRunFixture(raw),
+    });
+  }
+  return fixtures;
+}

--- a/packages/launcher/src/index.ts
+++ b/packages/launcher/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @prompttrail/launcher — B5, the immutable blue/green deploy launcher.
+ *
+ * This package is the TRUST ROOT of a self-modifying deployment (design-docs
+ * replay-and-self-deploy.md §5–§8). It must be installed/pinned OUTSIDE the
+ * candidate's write paths: claw's self-authoring only ever writes its `.data`
+ * dirs, never this package, so a self-modified build can never weaken the gate
+ * or seize the lease. See the package README for the immutability posture.
+ *
+ * It composes the already-merged machinery — B1 replay, B2 differ + ChangeScope,
+ * B3 acceptance, B4 store lease + fencing — and adds the irreversible cutover:
+ * verify → launch green → hand off the single-writer lease → health window →
+ * auto-rollback. The launcher decides; green only supplies evidence.
+ */
+export { deploy } from './deploy';
+export { verifyCandidate } from './verify';
+export type { VerifyResult } from './verify';
+export { launchServer } from './process';
+export type { LaunchServerOptions } from './process';
+export {
+  deserializeRunFixture,
+  readRunFixtures,
+  serializeRunFixture,
+} from './fixtures';
+export type { LoadedFixture, RunFixture } from './fixtures';
+export { LAUNCHER_ENV } from './types';
+export type {
+  DeployLogEvent,
+  DeployOptions,
+  DeployReport,
+  DeployTarget,
+  DeployVerdict,
+  FixtureDiff,
+  LaunchedProcess,
+  ProbeContext,
+  ServerRole,
+} from './types';

--- a/packages/launcher/src/process.ts
+++ b/packages/launcher/src/process.ts
@@ -1,0 +1,123 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { LAUNCHER_ENV } from './types';
+import type { DeployTarget, LaunchedProcess, ServerRole } from './types';
+
+export interface LaunchServerOptions {
+  /** Lease holder id the child must use (injected as LAUNCHER_LEASE_HOLDER). */
+  holder: string;
+  role: ServerRole;
+  ttlMs: number;
+  /** File the child touches when it is initialized + polling for the lease. */
+  readyFile: string;
+  /** File the child rewrites each tick with its {serving, token, ...} status. */
+  statusFile: string;
+}
+
+/**
+ * Spawn a server child from `target.serve`, injecting only the launcher-owned
+ * handshake env (role, holder, ttl, ready/status file paths). The child owns its
+ * own store/lease config via `target.serve.env`. Returns a {@link
+ * LaunchedProcess} handle the launcher uses to await readiness and reap the
+ * process; the store lease — not this handle — decides who actually serves.
+ */
+export function launchServer(
+  target: DeployTarget,
+  opts: LaunchServerOptions,
+): LaunchedProcess {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    ...(target.serve.env ?? {}),
+    [LAUNCHER_ENV.role]: opts.role,
+    [LAUNCHER_ENV.holder]: opts.holder,
+    [LAUNCHER_ENV.ttlMs]: String(opts.ttlMs),
+    [LAUNCHER_ENV.readyFile]: opts.readyFile,
+    [LAUNCHER_ENV.statusFile]: opts.statusFile,
+  };
+
+  const child: ChildProcess = spawn(target.serve.command, target.serve.args, {
+    cwd: target.serve.cwd,
+    env,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+
+  let exited = false;
+  let exitError: Error | undefined;
+  child.once('exit', (code, signal) => {
+    exited = true;
+    if (code && code !== 0) {
+      exitError = new Error(
+        `${opts.role} child exited early with code ${code}` +
+          (signal ? ` (signal ${signal})` : ''),
+      );
+    }
+  });
+  child.once('error', (error) => {
+    exited = true;
+    exitError = error instanceof Error ? error : new Error(String(error));
+  });
+
+  const handle: LaunchedProcess = {
+    holder: opts.holder,
+    role: opts.role,
+    get pid() {
+      return child.pid;
+    },
+    statusFile: opts.statusFile,
+    get exited() {
+      return exited;
+    },
+    async waitReady(timeoutMs = 10_000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      for (;;) {
+        if (existsSync(opts.readyFile)) {
+          return;
+        }
+        if (exited) {
+          throw (
+            exitError ??
+            new Error(`${opts.role} child exited before signaling ready`)
+          );
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `${opts.role} child did not signal ready within ${timeoutMs}ms`,
+          );
+        }
+        await delay(25);
+      }
+    },
+    async stop(timeoutMs = 5_000): Promise<void> {
+      if (exited) {
+        return;
+      }
+      const done = onceExit(child);
+      child.kill('SIGTERM');
+      const timedOut = await Promise.race([
+        done.then(() => false),
+        delay(timeoutMs).then(() => true),
+      ]);
+      if (timedOut && !exited) {
+        child.kill('SIGKILL');
+        await done;
+      }
+    },
+    kill(): void {
+      if (!exited) {
+        child.kill('SIGKILL');
+      }
+    },
+  };
+  return handle;
+}
+
+function onceExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => child.once('exit', () => resolve()));
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/launcher/src/types.ts
+++ b/packages/launcher/src/types.ts
@@ -1,0 +1,223 @@
+import type {
+  AcceptanceCase,
+  AcceptanceReport,
+  Agent,
+  ChangeScope,
+  DiffReport,
+  DurableRunStore,
+} from '@prompttrail/core';
+
+/**
+ * B5 — the immutable launcher (design-docs replay-and-self-deploy.md §5–§8).
+ *
+ * The launcher is the TRUST ROOT: a tiny, never-self-modified orchestrator that
+ * DECIDES and EXECUTES the irreversible parts of a self-deploy (lease handoff +
+ * rollback). It never imports candidate code into its own decision logic —
+ * verification runs are launcher-owned executions over launcher-owned corpus
+ * definitions (`DeployTarget.corpus`), and the candidate only ever appears as a
+ * loaded {@link Agent} passed *into* the trusted replay/diff/acceptance
+ * machinery. "Green proposes evidence, the launcher disposes." See §6.
+ */
+
+/**
+ * A deployable a launcher can (a) VERIFY against and (b) SERVE. v1 contract.
+ *
+ * The verification inputs are LAUNCHER-OWNED (they live on the target the
+ * trusted root constructs, NOT read out of the candidate directory), so a
+ * self-modified candidate cannot weaken its own gate (design §6).
+ */
+export interface DeployTarget {
+  /** Stable name for this deployable (surfaced in logs + the report). */
+  name: string;
+  /**
+   * Verification inputs. All launcher-owned: the launcher decides what to replay
+   * and what "regression" means; the candidate only supplies the agent to run.
+   */
+  corpus: {
+    /**
+     * Directory of recorded {@link import('@prompttrail/core').StoredRun} JSON
+     * fixtures (see `serializeRunFixture`) replayed for the diff. Each file is
+     * one past run; the launcher builds its cassette + golden outcome and
+     * replays the CANDIDATE agent against it. Omit to skip replay-diff.
+     */
+    runsDir?: string;
+    /** The declared intended blast radius; any diff outside it is a regression. */
+    scope: ChangeScope;
+    /** Forward fake-request acceptance cases (design §4). Omit to skip. */
+    acceptance?: AcceptanceCase[];
+  };
+  /**
+   * Load the candidate's agent for runner-executed verification — e.g. a dynamic
+   * import of the candidate's built dist. The launcher runs this agent through
+   * the TRUSTED replay/diff/acceptance machinery; it is never trusted to grade
+   * itself. `candidateDir` is the directory passed to {@link deploy}.
+   */
+  loadAgent: (candidateDir: string) => Promise<Agent>;
+  /**
+   * How to SERVE the candidate: the command the launcher spawns as the green
+   * child process. The child configures its OWN store/lease from this env; the
+   * launcher only injects the role + holder id (see {@link LAUNCHER_ENV}) and
+   * orchestrates who HOLDS the lease via the store handle it owns.
+   */
+  serve: {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+  };
+  /**
+   * The shared durable store whose single-writer lease arbitrates serving. The
+   * launcher OWNS this handle: it discovers the current (blue) holder and
+   * performs the atomic handoff/rollback directly on `store.lease`. Fencing
+   * makes a drained blue's late writes fail safely (the B4 guarantee).
+   */
+  store: DurableRunStore;
+  /**
+   * Independent, launcher-owned health probes (design §5/§6). Each throws to
+   * signal UNHEALTHY. They are re-verified by the launcher AFTER the cutover —
+   * they are NOT green's self-report. Used both to confirm green took over and
+   * to watch the post-cutover health window.
+   */
+  probes?: Array<(ctx: ProbeContext) => void | Promise<void>>;
+}
+
+/** Context handed to each health probe so it can inspect the green candidate. */
+export interface ProbeContext {
+  /** The lease holder id the launcher assigned to the green child. */
+  greenHolder: string;
+  /**
+   * Absolute path of the green child's status file (the launcher assigns it and
+   * passes it to the child via {@link LAUNCHER_ENV.statusFile}). A probe may read
+   * it, but the store lease is the authoritative signal.
+   */
+  statusFile: string;
+  /** The shared store, for lease-based liveness checks. */
+  store: DurableRunStore;
+}
+
+export interface DeployOptions {
+  /** Lease TTL in ms used for handoff/rollback. Default 30_000. */
+  ttlMs?: number;
+  /**
+   * How long (ms) to keep re-running the probes after the cutover before
+   * declaring the deploy healthy. A probe failure at any point rolls back.
+   * Default 3_000.
+   */
+  healthWindowMs?: number;
+  /** How long (ms) to wait for blue to drain + exit on promote. Default 5_000. */
+  drainTimeoutMs?: number;
+  /** Interval (ms) between probe iterations. Default 200. */
+  probeIntervalMs?: number;
+  /**
+   * How long (ms) to wait for the green child to signal ready (and, after
+   * cutover, to become healthy) before giving up. Default 10_000.
+   */
+  readyTimeoutMs?: number;
+  /**
+   * The currently-serving process the launcher manages (blue), if any. When
+   * present, deploy() drains+SIGTERMs it on a successful promote and leaves it
+   * WARM (untouched) through the health window so a rollback is an instant lease
+   * handoff back, not a cold restart (design §5). When absent, the launcher
+   * relies on blue self-exiting once it detects the lease loss.
+   */
+  current?: LaunchedProcess;
+  /** Clock for report timestamps. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Structured log sink for every stage transition. */
+  log?: (event: DeployLogEvent) => void;
+}
+
+/** The launcher's terminal verdict for a deploy attempt. */
+export type DeployVerdict = 'promoted' | 'rejected' | 'rolled-back';
+
+/** One replay-diff result over a single recorded fixture. */
+export interface FixtureDiff {
+  fixture: string;
+  kind: DiffReport['kind'];
+  outOfScope: DiffReport['outOfScope'];
+  misses: number;
+}
+
+export interface DeployReport {
+  verdict: DeployVerdict;
+  target: string;
+  /** Per-stage outcomes, filled in as the deploy progresses. */
+  stages: {
+    verify?: {
+      ok: boolean;
+      fixtures: number;
+      regressions: number;
+      acceptanceOk?: boolean;
+      error?: string;
+    };
+    launch?: { ok: boolean; holder?: string; pid?: number; error?: string };
+    cutover?: {
+      ok: boolean;
+      from?: string;
+      to?: string;
+      token?: number;
+      error?: string;
+    };
+    health?: { ok: boolean; error?: string; rolledBack?: boolean };
+    promote?: { ok: boolean; blueStopped?: boolean };
+  };
+  /** Every fixture's replay-diff classification (populated by VERIFY). */
+  diffs?: FixtureDiff[];
+  /** The acceptance report (populated by VERIFY when acceptance cases exist). */
+  acceptance?: AcceptanceReport;
+  /** Terminal error message when the deploy went to a safe state. */
+  error?: string;
+}
+
+/** A structured launcher log event (every stage transition emits one). */
+export interface DeployLogEvent {
+  stage:
+    | 'verify'
+    | 'launch'
+    | 'drain'
+    | 'cutover'
+    | 'health'
+    | 'promote'
+    | 'rollback'
+    | 'safe-state';
+  message: string;
+  at: number;
+  data?: Record<string, unknown>;
+}
+
+/** Role the launcher assigns to a spawned server child. */
+export type ServerRole = 'blue' | 'green';
+
+/**
+ * A handle to a spawned server child (blue or green). The launcher owns the OS
+ * process; the store lease (not this handle) is the source of truth for who is
+ * actually serving.
+ */
+export interface LaunchedProcess {
+  readonly holder: string;
+  readonly role: ServerRole;
+  readonly pid: number | undefined;
+  /** Absolute path of the child's status file (JSON, rewritten each tick). */
+  readonly statusFile: string;
+  /** True once the OS process has exited. */
+  readonly exited: boolean;
+  /** Resolve when the child signals ready; reject on timeout or early exit. */
+  waitReady(timeoutMs?: number): Promise<void>;
+  /** SIGTERM and await exit up to `timeoutMs`, then SIGKILL. Idempotent. */
+  stop(timeoutMs?: number): Promise<void>;
+  /** SIGKILL immediately (best-effort). Idempotent. */
+  kill(): void;
+}
+
+/**
+ * The environment variables the launcher injects into a server child. The
+ * deployable's OWN config (store path, etc.) rides `DeployTarget.serve.env`; the
+ * launcher only owns role + holder identity + the ready/status/ttl handshake.
+ */
+export const LAUNCHER_ENV = {
+  role: 'LAUNCHER_ROLE',
+  holder: 'LAUNCHER_LEASE_HOLDER',
+  ttlMs: 'LAUNCHER_TTL_MS',
+  readyFile: 'LAUNCHER_READY_FILE',
+  statusFile: 'LAUNCHER_STATUS_FILE',
+} as const;

--- a/packages/launcher/src/verify.ts
+++ b/packages/launcher/src/verify.ts
@@ -1,0 +1,74 @@
+import {
+  buildCassette,
+  buildGoldenOutcome,
+  DEFAULT_KEYING,
+  diffReplay,
+  replayRun,
+  runAcceptance,
+} from '@prompttrail/core';
+import type { AcceptanceReport, Agent } from '@prompttrail/core';
+import { readRunFixtures } from './fixtures';
+import type { DeployTarget, FixtureDiff } from './types';
+
+/**
+ * The VERIFY stage (design §5 corrected — the TRUSTED RUNNER executes against
+ * green as a target; green cannot grade itself). Runs entirely in the launcher
+ * process, SEALED: the candidate agent is loaded and driven through the core
+ * replay/diff/acceptance machinery over the LAUNCHER-OWNED corpus. No child
+ * process, no lease, no network, no store writes — deliveries are captured and
+ * discarded by the replay containment.
+ *
+ * 1. For each recorded fixture: build the cassette + golden outcome from the
+ *    stored recording, replay the CANDIDATE agent against it (`miss: 'flag'` so
+ *    a divergence is captured, not thrown), and `diffReplay` the result against
+ *    the declared scope. Any `regression` (a difference outside scope) rejects.
+ * 2. Then run the acceptance corpus against the candidate. Any failure rejects.
+ */
+export interface VerifyResult {
+  ok: boolean;
+  diffs: FixtureDiff[];
+  regressions: number;
+  acceptance?: AcceptanceReport;
+  error?: string;
+}
+
+export async function verifyCandidate(
+  agent: Agent,
+  corpus: DeployTarget['corpus'],
+): Promise<VerifyResult> {
+  const diffs: FixtureDiff[] = [];
+
+  if (corpus.runsDir) {
+    const fixtures = await readRunFixtures(corpus.runsDir);
+    for (const { name, run } of fixtures) {
+      // Attach the candidate agent to the fixture so the run is fully formed;
+      // replayRun is still given `agent` explicitly so keying stays candidate-side.
+      const candidateRun = { ...run, agent: agent as typeof run.agent };
+      const cassette = buildCassette(candidateRun);
+      const golden = buildGoldenOutcome(candidateRun);
+      const { trace } = await replayRun(candidateRun, {
+        agent,
+        cassette,
+        keying: DEFAULT_KEYING,
+        miss: 'flag',
+      });
+      const report = diffReplay(golden, trace, corpus.scope);
+      diffs.push({
+        fixture: name,
+        kind: report.kind,
+        outOfScope: report.outOfScope,
+        misses: trace.misses.length,
+      });
+    }
+  }
+
+  const regressions = diffs.filter((d) => d.kind === 'regression').length;
+
+  let acceptance: AcceptanceReport | undefined;
+  if (corpus.acceptance && corpus.acceptance.length > 0) {
+    acceptance = await runAcceptance(agent, corpus.acceptance);
+  }
+
+  const ok = regressions === 0 && (acceptance ? acceptance.ok : true);
+  return { ok, diffs, regressions, acceptance };
+}

--- a/packages/launcher/tsconfig.json
+++ b/packages/launcher/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020", "DOM"],
+    "composite": true,
+    "rootDir": "src",
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/launcher/tsup.config.ts
+++ b/packages/launcher/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  outDir: 'dist',
+});

--- a/packages/launcher/vitest.config.ts
+++ b/packages/launcher/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@prompttrail/core/runtime_server',
+        replacement: new URL('../core/src/runtime_server.ts', import.meta.url)
+          .pathname,
+      },
+      {
+        find: '@prompttrail/core',
+        replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
+      },
+    ],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    // Child processes are spawned, awaited-ready, cut over, and reaped; give the
+    // blue/green orchestration tests room without being flaky.
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/__tests__/**'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@prompttrail/discord':
         specifier: workspace:*
         version: link:../packages/discord
+      '@prompttrail/launcher':
+        specifier: workspace:*
+        version: link:../packages/launcher
       '@prompttrail/store-sqlite':
         specifier: workspace:*
         version: link:../packages/store-sqlite
@@ -300,6 +303,31 @@ importers:
         specifier: ^14.26.4
         version: 14.26.4
     devDependencies:
+      '@types/node':
+        specifier: ^20.17.19
+        version: 20.17.32
+      '@vitest/coverage-v8':
+        specifier: ^1.6.1
+        version: 1.6.1(vitest@1.6.1(@types/node@20.17.32)(lightningcss@1.29.2))
+      tsup:
+        specifier: ^8.3.6
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@20.17.32)(lightningcss@1.29.2)
+
+  packages/launcher:
+    dependencies:
+      '@prompttrail/core':
+        specifier: link:../core
+        version: link:../core
+    devDependencies:
+      '@prompttrail/store-sqlite':
+        specifier: workspace:*
+        version: link:../store-sqlite
       '@types/node':
         specifier: ^20.17.19
         version: 20.17.32
@@ -3010,7 +3038,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:


### PR DESCRIPTION
Completes the replay-and-self-deploy chain (B0 #68/#69 → B1 #71 → B2 #72 → B3 #73 → B4 #59/#61 → B5). 'Green proposes, launcher disposes':

- VERIFY (sealed, launcher-owned): replay-diff each recorded-run fixture against the declared ChangeScope — any regression rejects before anything launches; then the acceptance corpus
- CUTOVER: launcher owns the store handle and calls lease.handoff directly; green (LAUNCHER_ROLE=green) polls until it holds the lease; blue drops to warm standby on lease loss — its late writes are fenced (asserted in the promote test)
- HEALTH WINDOW: independent probes; failure hands the lease straight back to warm blue (instant rollback); success SIGTERMs blue
- Trust boundaries per §6 documented in the README: the launcher and corpus are trusted-root; claw's self-authoring can only write .data paths

launcher 5 tests (promote with fenced late write, out-of-scope regression rejection, acceptance rejection, rollback, fixture round-trip; child-process audit clean ×3 runs) using SqliteRunStore as cross-process IPC. Whole repo green: core 797 unit, claw 42, 11/11 packages, build/lint/prettier.